### PR TITLE
Prepare immutable native release 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: ci
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -82,7 +82,7 @@ jobs:
           path: .temp/gate-run/
 
   ci:
-    if: always()
+    if: ${{ always() && !cancelled() }}
     needs: [msrv, lint-test, integration]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         run: chmod +x test/check-boundaries.sh && ./test/check-boundaries.sh
 
   integration:
-    # Push/PR: one Ubuntu workspace round. Cross-platform qualification, timing
-    # rounds, coverage, and release packaging belong to the tag workflow.
+    # Push/PR: one Ubuntu workspace round. Cross-platform qualification,
+    # coverage, and release packaging belong to the tag workflow.
     needs: [msrv, lint-test]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,8 @@ jobs:
       - uses: ./.github/actions/setup-open-compute
         with:
           rust-cache-key: release-${{ matrix.target }}
+      - name: Fetch locked crates for offline packaged-binary tests
+        run: cargo fetch --locked
       - name: Package and verify the native single executable
         shell: bash
         env:
@@ -222,8 +224,7 @@ jobs:
             }
           '
           OPEN_COMPUTE_TEST_OCD="$destination" \
-            cargo test --locked --offline -p open-compute-service \
-              --test single_binary -- --test-threads=1
+            ./test/gate.py single-binary --jobs 1
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
@@ -233,6 +234,11 @@ jobs:
           if-no-files-found: error
           retention-days: 14
           compression-level: 0
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: package-gate-${{ matrix.target }}
+          path: .temp/gate-run/
 
   assemble:
     needs: [validate, package]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -72,6 +73,15 @@ jobs:
             echo "version=$version"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Require successful main CI for the exact release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml \
+            --branch main --event push --commit "$GITHUB_SHA" --status success \
+            --json databaseId --jq 'length')"
+          test "$count" -gt 0
+
   msrv:
     needs: validate
     runs-on: ubuntu-24.04
@@ -104,7 +114,7 @@ jobs:
         run: |
           bun run build
           bun run check:generated
-          bun run test:js
+          bun run test:js:ci
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s test -p 'test_gate.py'
       - name: fmt
         run: cargo fmt --all --check
@@ -120,7 +130,7 @@ jobs:
         run: chmod +x test/check-boundaries.sh && ./test/check-boundaries.sh
 
   coverage:
-    needs: validate
+    needs: [validate, msrv, lint-test]
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
@@ -138,10 +148,13 @@ jobs:
         if: always()
         with:
           name: coverage-gate-evidence
-          path: .temp/gate-run/
+          path: |
+            .temp/gate-run/
+            target/llvm-cov/summary.json
+            target/llvm-cov/lcov.info
 
   integration:
-    needs: [validate, msrv, lint-test]
+    needs: [validate, msrv, lint-test, coverage]
     strategy:
       fail-fast: false
       matrix:
@@ -152,12 +165,16 @@ jobs:
       - uses: ./.github/actions/setup-open-compute
         with:
           rust-cache-key: default
-      - name: Final workspace once and product timing cases three times (macOS)
+      - name: Build untracked runtime and toolchain assets from this checkout
+        run: bun run build
+      - name: Fetch locked crates for offline Gate compile
+        run: cargo fetch --locked
+      - name: Final workspace once (macOS)
         if: runner.os == 'macOS'
-        run: OPEN_COMPUTE_GATE_ROUNDS=3 ./test/gate.py --workspace --jobs 2
+        run: ./test/gate.py --workspace --jobs 2
       - name: Final workspace and controlled egress (Linux, explicit privilege authorization)
         if: runner.os == 'Linux'
-        run: OPEN_COMPUTE_GATE_ROUNDS=3 OPEN_COMPUTE_EGRESS_FIXTURE_ALLOW_SUDO=1 ./test/test-p0-2-egress-linux.sh --workspace --jobs 2
+        run: OPEN_COMPUTE_EGRESS_FIXTURE_ALLOW_SUDO=1 ./test/test-p0-2-egress-linux.sh --workspace --jobs 2
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -217,12 +234,9 @@ jobs:
           retention-days: 14
           compression-level: 0
 
-  publish:
+  assemble:
     needs: [validate, package]
     runs-on: ubuntu-24.04
-    environment: release
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -237,6 +251,29 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: bun scripts/assemble-release.ts --tag "$RELEASE_TAG" --dir "$GITHUB_WORKSPACE/.temp/release-assets"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: public-release
+          path: |
+            .temp/release-assets/ocd-*
+            .temp/release-assets/release.json
+            .temp/release-assets/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
+  publish:
+    needs: [validate, assemble]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: public-release
+          path: .temp/release-assets
       - name: Create a draft, verify uploaded bytes, and publish
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --draft \
-            --latest \
             --generate-notes \
             --title "open-compute $RELEASE_VERSION"
           verify="$RUNNER_TEMP/release-download"

--- a/crates/artifacts/src/local.rs
+++ b/crates/artifacts/src/local.rs
@@ -24,7 +24,9 @@ use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{Read, Seek as _, SeekFrom, Write as _};
-use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+#[cfg(target_os = "macos")]
+use std::os::unix::ffi::OsStrExt as _;
+use std::os::unix::ffi::OsStringExt as _;
 use std::str::FromStr as _;
 use std::sync::Arc;
 #[cfg(test)]
@@ -1668,8 +1670,8 @@ fn remove_stale_partial(
     let stat = fstat(&fd).map_err(|_| BackendError::Unavailable)?;
     budget.charge((stat.st_size as u64).min(HEADER_BYTES as u64))?;
     let modified_ms =
-        stat.st_mtime.saturating_mul(1_000) + stat.st_mtime_nsec.saturating_div(1_000_000);
-    if modified_ms <= cutoff_ms {
+        i128::from(stat.st_mtime) * 1_000 + i128::from(stat.st_mtime_nsec) / 1_000_000;
+    if modified_ms <= i128::from(cutoff_ms) {
         unlinkat(directory, name, AtFlags::empty()).map_err(|_| BackendError::Unavailable)?;
     }
     Ok(())

--- a/crates/runtime/src/fsutil_tests.rs
+++ b/crates/runtime/src/fsutil_tests.rs
@@ -65,7 +65,8 @@ fn path_open_mode_hash_and_remove_helpers_cover_failure_boundaries() {
 
 #[test]
 fn directory_walk_atomic_write_and_workspace_lifecycle_are_complete() {
-    let tmp = tempfile::tempdir().unwrap();
+    // Unix socket fixtures need a short path even under a deeply nested worktree.
+    let tmp = tempfile::tempdir_in("/tmp").unwrap();
     let root = tmp.path();
     let data = root.join("data");
     create_dir_secure(&data).unwrap();

--- a/crates/service/src/tests.rs
+++ b/crates/service/src/tests.rs
@@ -582,7 +582,8 @@ async fn listener_plan_and_task_join_errors_are_stable() {
 
 #[test]
 fn config_path_rejections_do_not_echo_secrets() {
-    let dir = TempDir::new().unwrap();
+    // Unix socket fixtures need a short path even under a deeply nested worktree.
+    let dir = TempDir::new_in("/tmp").unwrap();
     let rel = parse_from(["ocd", "run", "--config", "relative.toml"]).unwrap();
     let err = load_platform_config(rel.config.as_ref().unwrap()).unwrap_err();
     assert_eq!(err.code(), ErrorCode::ConfigPathInvalid);

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 
 | 文档 | 当前状态 |
 | --- | --- |
+| [macOS 解析进程内存限制](macos-document-parser.md) | TODO：RSS 硬限制待实现；0.1.0 接受此限制并保留完整格式支持 |
 | [P10 Dynamic Workers / Worker Loader](p10-dynamic-workers-worker-loader.md) | 合同与架构完成；`worker_loaders` v4/Version 支持受 upstream stock workerd nested-loader、limits 与 bounded-cache G0 阻断；Workers for Platforms 不在范围内 |
 | [P11 Cloudflare Artifacts](p11-cloudflare-artifacts.md) | Day 1 合同与架构完成；标准 v4/Worker binding/Git Smart HTTP 受进程内 Git engine G0 阻断；不把现有内部 ArtifactStore 或 LynxOS 文件夹伪装成 Cloudflare Artifacts |
 | [P12 Cloudflare Browser Run](p12-browser-run.md) | Day 1 合同与架构完成；标准 binding/Quick Actions/DevTools/CDP 通过 operator-owned 外部 Browser Provider 执行，受真实 stock-workerd/package/provider G0 阻断；正式 open-compute 发布仍是单个 `ocd` |

--- a/docs/acceptance/README.md
+++ b/docs/acceptance/README.md
@@ -7,6 +7,7 @@
 
 | 文档 | 当前缺口 |
 | --- | --- |
+| [首次发行 0.1.0](first-release-0.1.0.md) | 发布流程修复与本地验证准备中；GitHub 设置、四平台资格和公开 Release 待执行 |
 | [P1 剩余验收](p1-release-acceptance.md) | 长时 soak 与正式发行演练尚无完成证据 |
 | [Runtime 跨平台发行验收](runtime-layout-release-acceptance.md) | CI、跨平台、特权 egress 与正式发行资格尚未执行 |
 | [Cloudflare Workflow 远端 differential](cloudflare-runtime-compatibility-acceptance.md) | 本地实现完成；托管端仍受 credential 条件阻塞 |

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -1,0 +1,46 @@
+# 首次发行 0.1.0 验收
+
+日期：2026-09-05。状态：准备中；尚未创建 `v0.1.0`，尚无公开 Release。
+
+## 固定输入与范围
+
+- 从 `main` 的 `62cb7a0c92059b9cc7a4c956915094d671d075b1` 创建 `codex/release-0.1.0`。
+  当前独立 R2 修复分支不在本次发布准备变更内；最终源码以合入 main 后的 annotated tag 为准。
+- Cargo workspace 与 lockfile 已是 `0.1.0`，不制造无意义的版本或 lockfile 变动。
+- workerd 保持 `v1.20260830.1`，revision `e9dda5963aba7ee4323960db795690ec78fec118`，
+  compatibility date `2026-08-30`；四平台摘要以正式 `packages/runtime/workerd.lock.json` 为准。
+- 修复 Local artifacts 在 Linux 上的时间戳整数类型与条件 import 编译失败；保留已有
+  stale partial grace-period、符号链接拒绝和 crash-recovery 测试。
+- release 先完成静态检查与 90% coverage，再运行 Linux/macOS 各一轮完整 Gate；每个 job 显式构建
+  runtime assets。四平台产物经只读聚合，再由 release environment 中唯一写权限 job 发布。
+- tag 必须对应已经通过 main push CI 的精确 commit；不修改已推送 tag，不覆盖既有 assets。
+
+## 发布内容与限制
+
+仅发布 darwin-arm64、darwin-x64、linux-arm64、linux-x64 四个原生单文件 `ocd`，
+以及 `release.json` 和 `SHA256SUMS`。生产启动离线，无 sidecar 或独立 workerd 下载。
+下载和校验步骤见[发布参考](../references/releasing.md)，部署契约见
+[单二进制指南](../references/single-binary.md)。
+
+本次不改变 Cloudflare API 支持范围和 workerd pin。Workers Standard request/isolate 资源限制执行器
+仍受 upstream 阻断，见 [P9 限制](../blocked/p9-workers-standard-limits.md)。长时 soak、签名/公证、
+托管端差分与第三方应用重验不能由本次原生发行替代，其他缺口见[验收索引](README.md)。
+完整 `bun run test:js` 的 vinext 冻结输入检查报告 `root lock digest drift`；215 个平台 JS 用例通过。
+release 与普通 CI 使用相同的 `test:js:ci` 平台集合，不重写历史应用报告或冻结摘要来制造通过结果。
+
+## 待收集的发行证据
+
+- [x] 本地 build、generated assets、215/215 平台 JS 测试、Python Gate 工具测试、文档构建、
+  fmt、Clippy、no-default-features、MSRV 1.98、metadata、dependency boundaries、production hygiene。
+- [ ] coverage 和最终单轮 workspace Gate。coverage 首次尝试在准备阶段因文档继续编辑触发
+  `source or verified inputs changed during the Gate`，尚未执行产品用例；保留失败报告
+  `.temp/gate-run/failed/20260905T144303-2687d286/report.json`。后续冻结全部源码和文档再执行。
+- [x] GitHub API 回读：main required `ci`（包含管理员，禁止 force push/delete）；release environment
+  仅接受 `v*` tag；`Release tags` ruleset `22323316` 限制 tag 创建/更新/删除，只有 repository admin
+  maintainer 可 bypass；默认 token read-only；immutable releases 已启用。
+- [ ] 发布 PR、main CI、annotated tag commit 和 release workflow URL。
+- [ ] Linux/macOS 单轮 Gate、90% coverage、Linux 特权 egress 及清理结果。
+- [ ] 四平台 package report、单文件隔离/首启/重启/损坏拒绝、六个 assets 的回读校验。
+- [ ] 正式 latest Release、逐目标文件大小/SHA-256、发布完成时间。
+
+未完成上述验证前保留本文于 acceptance；完成后将实际结果归档到 implemented 并更新索引。

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -24,11 +24,16 @@
 下载和校验步骤见[发布参考](../references/releasing.md)，部署契约见
 [单二进制指南](../references/single-binary.md)。
 
-本次不改变 Cloudflare API 支持范围和 workerd pin。Workers Standard request/isolate 资源限制执行器
+本次保持 workerd pin 与完整的 13 种文档格式支持。macOS 解析子进程缺少内存硬上限，
+经明确决定接受为 0.1.0 限制；现有其他资源约束继续生效，见 [TODO](../macos-document-parser.md)。
+撤回此前本地禁用格式的修改，生产解析源码、测试与 parser contract 摘要恢复到原实现。Workers Standard request/isolate 资源限制执行器
 仍受 upstream 阻断，见 [P9 限制](../blocked/p9-workers-standard-limits.md)。长时 soak、签名/公证、
 托管端差分与第三方应用重验不能由本次原生发行替代，其他缺口见[验收索引](README.md)。
 完整 `bun run test:js` 的 vinext 冻结输入检查报告 `root lock digest drift`；215 个平台 JS 用例通过。
 release 与普通 CI 使用相同的 `test:js:ci` 平台集合，不重写历史应用报告或冻结摘要来制造通过结果。
+
+PR CI `33951624671` 的产品 Gates 通过，但 `p3-contract` 的 source baseline 摘要漂移导致整体失败；
+其余 13 项合同检查通过。当前实现变更完成后重新冻结源码摘要，不改写历史报告。
 
 ## 待收集的发行证据
 

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -39,11 +39,15 @@ release 与普通 CI 使用相同的 `test:js:ci` 平台集合，不重写历史
   `.temp/gate-run/failed/20260905T144303-2687d286/report.json`。后续冻结全部源码和文档再执行。
   冻结尝试 `20260905T144805-3eb77e36` 的 service 单元测试 369/370，通过前置检查后在 Unix socket
   fixture 上遇到 macOS `SUN_LEN` 路径长度限制；两个 socket fixture 改用自动清理的短 OS 临时目录，
-  不修改 production 文件系统校验。对应失败报告继续保留，修复后重新验证。
+  不修改 production 文件系统校验。对应失败报告继续保留；修复后 service 单元测试 370/370 通过。
+  本地缓存符号链接布局导致 profile 遍历不完整的尝试已中止并保留证据；修正布局后的
+  `20260905T150007-fefe2ae0` 在 P0.7/P0.8 返回 `DO_STORAGE_LIMIT`：本机磁盘使用率超过默认
+  95% DO 停写水位，剩余约 6 GiB。未降低水位、未删除旧缓存或失败证据；本地 coverage 和后续
+  最终 workspace Gate 未通过，发行所需完整证据改由 GitHub 托管 runner 收集。
 - [x] GitHub API 回读：main required `ci`（包含管理员，禁止 force push/delete）；release environment
   仅接受 `v*` tag；`Release tags` ruleset `22323316` 限制 tag 创建/更新/删除，只有 repository admin
   maintainer 可 bypass；默认 token read-only；immutable releases 已启用。
-- [ ] 发布 PR、main CI、annotated tag commit 和 release workflow URL。
+- [ ] [发布 PR #5](https://github.com/elliothux/open-compute/pull/5)、main CI、annotated tag commit 和 release workflow URL。
 - GitHub 托管 runner 的特权 egress 操作已获用户明确授权；本机不运行 sudo。
 - [ ] Linux/macOS 单轮 Gate、90% coverage、Linux 特权 egress 及清理结果。
 - [ ] 四平台 package report、单文件隔离/首启/重启/损坏拒绝、六个 assets 的回读校验。

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -35,6 +35,9 @@ release 与普通 CI 使用相同的 `test:js:ci` 平台集合，不重写历史
 PR CI `33951624671` 的产品 Gates 通过，但 `p3-contract` 的 source baseline 摘要漂移导致整体失败；
 其余 13 项合同检查通过。当前实现变更完成后重新冻结源码摘要，不改写历史报告。
 
+恢复完整解析后的 PR CI `33953626108` 已全部通过。旧的重复 push 运行在取消后留下失败的 `ci`，
+导致分支保护拒绝合并；修复为 PR + main push 触发，并让取消的工作流跳过汇总，避免重复 Gate 与错误失败状态。
+
 ## 待收集的发行证据
 
 - [x] 本地 build、generated assets、215/215 平台 JS 测试、Python Gate 工具测试、文档构建、

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -11,6 +11,8 @@
   compatibility date `2026-08-30`；四平台摘要以正式 `packages/runtime/workerd.lock.json` 为准。
 - 修复 Local artifacts 在 Linux 上的时间戳整数类型与条件 import 编译失败；保留已有
   stale partial grace-period、符号链接拒绝和 crash-recovery 测试。
+- 原生 package job 显式 `cargo fetch --locked`，通过统一 `single-binary` Gate 核对 discovery 与数量，
+  并上传每个平台的 Gate 证据。
 - release 先完成静态检查与 90% coverage，再运行 Linux/macOS 各一轮完整 Gate；每个 job 显式构建
   runtime assets。四平台产物经只读聚合，再由 release environment 中唯一写权限 job 发布。
 - tag 必须对应已经通过 main push CI 的精确 commit；不修改已推送 tag，不覆盖既有 assets。
@@ -35,10 +37,14 @@ release 与普通 CI 使用相同的 `test:js:ci` 平台集合，不重写历史
 - [ ] coverage 和最终单轮 workspace Gate。coverage 首次尝试在准备阶段因文档继续编辑触发
   `source or verified inputs changed during the Gate`，尚未执行产品用例；保留失败报告
   `.temp/gate-run/failed/20260905T144303-2687d286/report.json`。后续冻结全部源码和文档再执行。
+  冻结尝试 `20260905T144805-3eb77e36` 的 service 单元测试 369/370，通过前置检查后在 Unix socket
+  fixture 上遇到 macOS `SUN_LEN` 路径长度限制；两个 socket fixture 改用自动清理的短 OS 临时目录，
+  不修改 production 文件系统校验。对应失败报告继续保留，修复后重新验证。
 - [x] GitHub API 回读：main required `ci`（包含管理员，禁止 force push/delete）；release environment
   仅接受 `v*` tag；`Release tags` ruleset `22323316` 限制 tag 创建/更新/删除，只有 repository admin
   maintainer 可 bypass；默认 token read-only；immutable releases 已启用。
 - [ ] 发布 PR、main CI、annotated tag commit 和 release workflow URL。
+- GitHub 托管 runner 的特权 egress 操作已获用户明确授权；本机不运行 sudo。
 - [ ] Linux/macOS 单轮 Gate、90% coverage、Linux 特权 egress 及清理结果。
 - [ ] 四平台 package report、单文件隔离/首启/重启/损坏拒绝、六个 assets 的回读校验。
 - [ ] 正式 latest Release、逐目标文件大小/SHA-256、发布完成时间。

--- a/docs/acceptance/p5-release-acceptance.md
+++ b/docs/acceptance/p5-release-acceptance.md
@@ -23,8 +23,10 @@
    p95、RSS 与 quota Go；没有留存报告时不把设计文档中的工程数字提升为 release SLA。
 2. Linux x64/arm64、macOS x64/arm64 的 Rust 1.98 release build、正式 package、单 binary size/hash 与隔离离线启动。
 3. parser child 的完整 panic/abort/OOM/signal/orphan cleanup/crash recovery/soak 矩阵，以及各平台实际 CPU、
-   address-space 与 process-group hard-limit 行为。Darwin 当前拒绝 `setrlimit(RLIMIT_AS)`；必须在 macOS 发行前
-   落实并验证等价 RSS hard limit，不能把 Linux 的 2 GiB `RLIMIT_AS` 结果外推到 macOS。
+   address-space 与 process-group hard-limit 行为。Darwin 当前拒绝 `setrlimit(RLIMIT_AS)`；
+   2026-09-05 明确接受 macOS 解析子进程无内存硬上限作为 0.1.0 的已知限制，保留完整格式支持。
+   RSS 硬限制移为[待实施 TODO](../macos-document-parser.md)，不再作为此次发行阻断条件。
+   其他现有 CPU、输入/输出、并发、超时和进程清理限制继续生效；Linux 结果不外推到 macOS。
 4. 使用专属临时资源对 Cloudflare 托管 Markdown Conversion rich-document output/error/limit 做 differential；
    不复用或修改账号既有 Worker、Vectorize index、AI Search instance、AI Gateway 或数据源。
 5. release artifact 的 license/NOTICE、签名、发布与受权限约束的外部资格。

--- a/docs/macos-document-parser.md
+++ b/docs/macos-document-parser.md
@@ -1,0 +1,28 @@
+# macOS 解析子进程内存硬限制 TODO
+
+状态：待实现；2026-09-05 明确接受为 0.1.0 发行限制，不阻断完整文档解析功能。
+
+## 当前行为与边界
+
+Linux 和 macOS 均保留 TXT、Markdown、HTML、XML、JSON、CSV、文本层 PDF、DOCX、XLSX、XLSM、XLS、ODT 和 ODS。
+`AI.toMarkdown()`、handle `transform()`、`supported()` 和 AI Search 文档索引不缩减格式集合。
+
+解析器由 `ocd` 按需启动为短命子进程，执行同一个二进制的私有 `__document-parser-v1` 入口。
+它不是另行分发或常驻部署的 sidecar；生产发行仍只有一个 `ocd` 可执行文件。
+解析进程有独立地址空间，不属于 workerd Worker isolate 的资源额度，但仍消耗宿主内存。
+
+Linux 使用 `RLIMIT_AS` 强制限制解析进程地址空间。Darwin 拒绝当前 `RLIMIT_AS` 设置；
+macOS 的 `document_parser.max_address_space_bytes` 因此不提供强制内存上限，也尚无等价 RSS 硬限制。
+地址空间上限与 RSS 上限并非同一个度量，不能把 Linux 结果外推到 macOS。
+
+现有输入、输出、容器展开、批次、并发、CPU、wall-clock timeout、进程组终止与回收限制继续生效。
+这些约束降低资源消耗风险，但不保证恶意或异常文档不会造成宿主内存压力，也不保证宿主 OOM 时主服务不受影响。
+本次明确接受的是 macOS 解析子进程缺少内存硬上限；不是取消其余限制，也不是宣称内存隔离已经验证。
+
+## 后续工作
+
+- [ ] 实现可执行的 macOS parser 内存硬限制，明确 RSS/地址空间度量与超限行为。
+- [ ] 在 arm64/x64 正式二进制上验证正常解析、超限终止、CPU、超时、进程组与孤儿清理。
+- [ ] 保留超限后的主服务可用性与 AI Search 失败/恢复证据，再关闭本 TODO。
+
+历史 parser corpus 和运行报告保持原样；它们证明对应解析路径，不能证明尚未实现的内存硬限制。

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -25,10 +25,10 @@ GitHub Releases 是公开二进制的唯一权威来源。每个 release 固定�
 
 ## 两条工作流
 
-`.github/workflows/ci.yml` 在分支 push 和 pull request 上运行。它负责 MSRV、TypeScript/生成资产、
+`.github/workflows/ci.yml` 在 main push 和 pull request 上运行。它负责 MSRV、TypeScript/生成资产、
 JS/Python 测试、format、Clippy、no-default-features、metadata、production hygiene、依赖边界，以及
 Ubuntu 上一个完整 workspace Gate round。普通 CI 不执行 release packaging，不创建 GitHub Release，
-也不上传公开二进制。同一来源分支的 push/PR 共用 concurrency group，取消被新运行取代的旧运行。分支保护只需要把汇总 job `ci` 设为 required check。
+也不上传公开二进制。功能分支通过 PR 验证，避免同一提交重复触发 push/PR Gate。各 PR 与 main 使用独立 concurrency group，取消过期运行；取消的 workflow 不执行失败汇总。分支保护只需要把汇总 job `ci` 设为 required check。
 
 `.github/workflows/release.yml` 只由 `v*` tag push 触发；工作流首先拒绝不满足以下全部条件的 tag：
 

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -1,5 +1,11 @@
 # 版本与发布流程
 
+macOS 的文档解析功能完整保留，但解析子进程尚无可强制执行的内存硬上限。
+0.1.0 接受该限制；CPU、输入/输出、并发和超时约束继续生效。
+该进程复用同一个 `ocd`，不属于 workerd Worker isolate 的额度，也不增加 sidecar 分发文件。
+宿主内存压力仍可能影响主服务，后续工作见 [macOS 内存限制 TODO](../macos-document-parser.md)。
+
+
 open-compute 只发布标准稳定版本和四个平台的原生单文件 `ocd`。版本使用不带预发布或构建后缀的
 SemVer：Cargo 版本写作 `X.Y.Z`，Git tag 写作 `vX.Y.Z`。不使用 `alpha`、`beta`、`rc`、
 `alpha.1` 或浮动的 nightly 版本。

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -31,17 +31,23 @@ Ubuntu 上一个完整 workspace Gate round。普通 CI 不执行 release packag
 3. tag、checkout 和 `GITHUB_SHA` 指向同一个 commit；
 4. 该 commit 已经可从 `origin/main` 到达；
 5. tag 版本等于根 `Cargo.toml` 的 `[workspace.package].version`；
-6. checkout 干净。
+6. checkout 干净；
+7. 同一 commit 已通过 `main` push 的 `ci.yml` 工作流。
 
-校验通过后，release workflow 才执行 Linux/macOS 静态检查、90% Rust 行覆盖率、完整一次加时序用例
-两次的最终 Gate，以及 Linux 受控 egress fixture。所有资格校验成功后，四个原生 runner 分别使用正式
+校验通过后，release workflow 才执行 Linux/macOS 静态检查、90% Rust 行覆盖率、完整单轮
+最终 workspace Gate（coverage 成功后执行），以及 Linux 受控 egress fixture。所有资格校验成功后，四个原生 runner 分别使用正式
 workerd lock 打包自己的 `ocd`，并以 `OPEN_COMPUTE_TEST_OCD` 跑单文件隔离、首启、重启和损坏拒绝测试。
 
-聚合 job 只接受四个精确命名的二进制和对应 package report；它重新核对版本、revision、workerd pin、
-lock SHA-256、文件大小与文件 SHA-256，然后生成 `release.json` 和 `SHA256SUMS`。发布 job 的默认权限
+只读 `assemble` job 只接受四个精确命名的二进制和对应 package report；它重新核对版本、revision、workerd pin、
+lock SHA-256、文件大小与文件 SHA-256，然后生成 `release.json` 和 `SHA256SUMS`。工作流的默认权限
 是只读，只有 `release` environment 中的最后一个 job 获得 `contents: write`。该 job 先创建 Draft
 GitHub Release，上传六个公开 assets，再全部下载回来逐字节比较并执行 `sha256sum --check`；全部通过
 后才把 Draft 变成正式 latest release。任一目标或回读校验失败时，不会出现部分公开 release。
+
+CI 和 release 都使用 `bun run test:js:ci` 的平台工具/runtime 测试集合。第三方应用 qualification
+独立执行，不属于 workspace Gate 或此次原生二进制发行资格。当前 `test:js` 额外包含的 vinext
+冻结输入检查存在 `root lock digest drift`；旧应用报告不证明当前源码，不能因此声称当前版本通过
+vinext/Next.js 端到端或 hosted Cloudflare differential。其冻结摘要和历史报告保持原样。
 
 ## 发布一个版本
 
@@ -65,13 +71,19 @@ git tag -a v0.1.0 -m "open-compute v0.1.0"
 git push origin v0.1.0
 ```
 
-push tag 是唯一发布触发器。随后在 GitHub Actions 的 `release` workflow 中确认所有 qualification、
-四目标 package 和 `publish` job 成功，并在 GitHub Release 页面核对六个 assets。仓库设置建议同时使用：
+每个 Gate job 都先显式执行 `bun run build` 和 `cargo fetch --locked`；打包脚本独立从源码构建。
+最终 Gate 不设置三轮诊断变量，遵循[单轮测试政策](testing.md)。
 
-- ruleset 限制 `v*` tag 只能由 release maintainer 创建；
-- `release` environment 限制可批准/运行发布的 maintainer；
+push tag 是唯一发布触发器。随后在 GitHub Actions 的 `release` workflow 中确认所有 qualification、
+四目标 package 和 `publish` job 成功，并在 GitHub Release 页面核对六个 assets。仓库已配置以下设置（2026-09-05 API 回读）：
+
+- main 分支要求 PR、最新 required `ci` 成功和讨论解决，禁止强推/删除；管理员同样受检查约束；
+- `Release tags` ruleset 限制 `v*` tag 创建/更新/删除，仅 repository admin maintainer 可 bypass；
+- `release` environment 仅允许 `v*` tag，发布入口由上述 maintainer tag 规则控制；
 - 启用 GitHub immutable releases，使已发布 tag 和 assets 不能被修改或删除；
 - Actions 默认 token 权限保持 read-only，由 workflow 仅给 `publish` job 提升 `contents: write`。
+
+首次 `0.1.0` 的源码范围、验证状态和已知限制记录在[发行验收](../acceptance/first-release-0.1.0.md)。
 
 ## 安装与校验
 

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -22,7 +22,7 @@ GitHub Releases 是公开二进制的唯一权威来源。每个 release 固定�
 `.github/workflows/ci.yml` 在分支 push 和 pull request 上运行。它负责 MSRV、TypeScript/生成资产、
 JS/Python 测试、format、Clippy、no-default-features、metadata、production hygiene、依赖边界，以及
 Ubuntu 上一个完整 workspace Gate round。普通 CI 不执行 release packaging，不创建 GitHub Release，
-也不上传公开二进制。分支保护只需要把汇总 job `ci` 设为 required check。
+也不上传公开二进制。同一来源分支的 push/PR 共用 concurrency group，取消被新运行取代的旧运行。分支保护只需要把汇总 job `ci` 设为 required check。
 
 `.github/workflows/release.yml` 只由 `v*` tag push 触发；工作流首先拒绝不满足以下全部条件的 tag：
 

--- a/docs/references/single-binary.md
+++ b/docs/references/single-binary.md
@@ -1,5 +1,11 @@
 # 单二进制分发与部署
 
+macOS 的文档解析功能完整保留，但解析子进程尚无可强制执行的内存硬上限。
+0.1.0 接受该限制；CPU、输入/输出、并发和超时约束继续生效。
+该进程复用同一个 `ocd`，不属于 workerd Worker isolate 的额度，也不增加 sidecar 分发文件。
+宿主内存压力仍可能影响主服务，后续工作见 [macOS 内存限制 TODO](../macos-document-parser.md)。
+
+
 Open Compute 只有一种生产发行形式：按平台构建的单个 `ocd` 可执行文件。
 不发布 Rust crate，不提供“外部 workerd”“外部资源目录”或自动下载模式。
 `runtime.binary`、`runtime.lock_file`、`runtime.assets_dir` 是未知配置项，启动前即拒绝。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "7d8fead145f40aed292faace8dac6ea939148a58ec50f364472657d75c0cc58b",
+  "openComputeRevision": "1e7c077f82b0bba957c04e3884497092af8b01a429dfc180b915c6b6ed52e3e0",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "e6de2a2ce5d90deddaaacc40529f573ade9b8c0c4fa25565a06ccd1c826210db",
+  "openComputeRevision": "7d8fead145f40aed292faace8dac6ea939148a58ec50f364472657d75c0cc58b",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {


### PR DESCRIPTION
The tag workflow could not qualify a release: Linux artifact timestamps failed to compile, integration jobs did not build generated runtime assets, and final Gates still requested three rounds. Fix the Linux timestamp arithmetic/import and prepare the first stable 0.1.0 release using the existing workspace version and unchanged workerd v1.20260830.1 pin.

Release qualification now requires successful CI on the exact main commit, runs static checks and 90% coverage before a single final workspace round per host, builds all four native executables, and assembles the manifest with read-only permissions. Only the release-environment publish job can upload and publish; its draft must pass complete byte-for-byte download verification first. The repository now has required main CI, maintainer tag rules, a tag-only release environment, and immutable releases enabled.

Validation completed locally: runtime build/generated checks, 215 platform JS tests, Python Gate-tool tests, docs build, fmt, Clippy, no-default-features, Rust 1.98 MSRV, metadata, dependency boundaries, and production hygiene. Full workspace coverage/Gate evidence must come from hosted qualification. Local coverage exposed Unix-socket test paths exceeding macOS SUN_LEN in deep worktrees; the fixtures now use automatically cleaned short OS temporary directories and the service unit suite passed 370/370. After fixing the local shared-cache layout, P0.7/P0.8 correctly refused writes because this host exceeds the default 95% disk stop-writes watermark (about 6 GiB free). All failed/interrupted evidence is retained; no watermark, assertion, or coverage threshold was weakened. The final uninstrumented Gate remains required after hosted coverage succeeds.

All 13 document formats remain supported on Linux and macOS. The macOS parser child has no enforceable memory ceiling; the user explicitly accepts this as a 0.1.0 limitation, with the RSS-limit TODO tracked separately. Input/output, CPU, concurrency, timeout and process cleanup bounds remain intact. The parser is an on-demand child of the same executable, separate from workerd isolate accounting; host memory pressure can still affect the daemon. No Cloudflare compatibility surface or workerd pin changes. Workers Standard runtime limit enforcement, hosted differential, long soak, signing/notarization, and application qualification remain outside this native release's evidence. The historical vinext frozen-input check currently fails on root-lock drift; release uses the same platform JS suite as ordinary CI and does not rewrite that historical evidence. See docs/acceptance/first-release-0.1.0.md for exact scope and remaining qualification.

The mandatory conformance source baseline is refreshed for the reviewed release inputs; all 14 contract checks pass locally. Historical differential/application reports remain unchanged.

PR CI 33953626108 passed completely. A duplicate branch-push run left a failed aggregate when cancelled, so branch protection correctly blocked merging. CI now runs on pull requests and main pushes, with event-scoped concurrency and no aggregate on cancelled runs.
