### PR TITLE
fix(test): prevent orphan cleanup from racing daemon restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,10 @@ jobs:
         if: always()
         with:
           name: gate-evidence-ubuntu-24.04
-          path: .temp/gate-run/
+          include-hidden-files: true
+          path: |
+            .temp/gate-run/
+            .temp/**/failed/**/ocd.log
 
   ci:
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,8 +148,10 @@ jobs:
         if: always()
         with:
           name: coverage-gate-evidence
+          include-hidden-files: true
           path: |
             .temp/gate-run/
+            .temp/**/failed/**/ocd.log
             target/llvm-cov/summary.json
             target/llvm-cov/lcov.info
 
@@ -179,7 +181,10 @@ jobs:
         if: always()
         with:
           name: gate-evidence-${{ matrix.os }}
-          path: .temp/gate-run/
+          include-hidden-files: true
+          path: |
+            .temp/gate-run/
+            .temp/**/failed/**/ocd.log
 
   package:
     needs: [validate, msrv, lint-test, coverage, integration]
@@ -238,7 +243,10 @@ jobs:
         if: always()
         with:
           name: package-gate-${{ matrix.target }}
-          path: .temp/gate-run/
+          include-hidden-files: true
+          path: |
+            .temp/gate-run/
+            .temp/**/failed/**/ocd.log
 
   assemble:
     needs: [validate, package]

--- a/crates/service/tests/p2_exit_gate.rs
+++ b/crates/service/tests/p2_exit_gate.rs
@@ -91,7 +91,7 @@ async fn p2_chain_preserves_queue_handoff_frozen_workflow_and_due_work_across_si
         1
     );
     crash(&mut process);
-    process = spawn(&config, &log);
+    process.restart(&config, &log);
     ready(&client, admin, &mut process).await;
     let identity: String = wait(
         &mut process,
@@ -118,7 +118,7 @@ async fn p2_chain_preserves_queue_handoff_frozen_workflow_and_due_work_across_si
     // The consumer created a Workflow, but its acknowledgement has not committed.
     // Redelivery must find that same instance rather than losing or duplicating it.
     crash(&mut process);
-    process = spawn(&config, &log);
+    process.restart(&config, &log);
     ready(&client, admin, &mut process).await;
     request(&client, public, "/release-consumer/chain", json!({})).await;
     wait(&mut process, "redelivered consumer acknowledgement", || {
@@ -168,7 +168,7 @@ async fn p2_chain_preserves_queue_handoff_frozen_workflow_and_due_work_across_si
     // Kill an actual ocd while a callback owns an uncommitted attempt.
     // Its completed sibling remains immutable, while Unknown reissues the same attempt.
     crash(&mut process);
-    process = spawn(&config, &log);
+    process.restart(&config, &log);
     ready(&client, admin, &mut process).await;
     let (next_fence, next_attempt) = wait(&mut process, "Unknown callback recovery", || {
         grant(&database).filter(|(next, _)| next.run_token != fence.run_token)
@@ -223,7 +223,7 @@ async fn p2_chain_preserves_queue_handoff_frozen_workflow_and_due_work_across_si
     setup::activate_future(&fixture).await;
     let delay = u64::try_from(due.saturating_sub(p0_exit_support::now_ms()).max(0)).unwrap();
     tokio::time::sleep(Duration::from_millis(delay.max(2200))).await;
-    process = spawn(&config, &log);
+    process.restart(&config, &log);
     ready(&client, admin, &mut process).await;
     assert_eq!(
         request(&client, public, "/status/chain", json!({})).await["status"],

--- a/crates/service/tests/p6_wrangler_resource_gate.rs
+++ b/crates/service/tests/p6_wrangler_resource_gate.rs
@@ -103,7 +103,7 @@ async fn fixed_wrangler_resource_commands_use_live_v4_authorities() {
         "normal shutdown left the admin listener reachable",
     );
 
-    fixture.process = platform_process::spawn(&fixture.config, &fixture.log);
+    fixture.process.restart(&fixture.config, &fixture.log);
     let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
         .build_http();
     wait_ready(

--- a/crates/service/tests/workflow_support/platform_process.rs
+++ b/crates/service/tests/workflow_support/platform_process.rs
@@ -68,6 +68,21 @@ async fn admin_response(
 
 pub(crate) struct Process(pub(crate) Child, PathBuf, String);
 impl Process {
+    #[allow(dead_code, reason = "only restart Gates use this method")]
+    pub(crate) fn restart(&mut self, config: &Path, log: &Path) {
+        assert!(
+            self.0.try_wait().unwrap().is_some(),
+            "ocd must exit before restart"
+        );
+        let parsed =
+            open_compute_core::PlatformConfig::from_toml_str(&fs::read_to_string(config).unwrap())
+                .unwrap();
+        assert_eq!(parsed.data.path.join("runtime/child.lease"), self.1);
+        // Keep the cleanup guard alive across generations. The new daemon must
+        // recover its orphan itself, without racing the old guard's Drop.
+        self.0 = spawn_child(config, log);
+    }
+
     #[allow(
         dead_code,
         reason = "only process Gates that require graceful exit call this"
@@ -177,33 +192,36 @@ pub(crate) fn spawn(config: &Path, log: &Path) -> Process {
             .unwrap();
     let (lock, _) = open_compute_runtime::embedded_runtime_lock().unwrap();
     let digest = lock.current_target().unwrap().1.binary_sha256.clone();
+    Process(
+        spawn_child(config, log),
+        parsed.data.path.join("runtime/child.lease"),
+        digest,
+    )
+}
+
+fn spawn_child(config: &Path, log: &Path) -> Child {
     let output = fs::OpenOptions::new()
         .create(true)
         .append(true)
         .mode(0o600)
         .open(log)
         .unwrap();
-    Process(
-        Command::new(env!("CARGO_BIN_EXE_ocd"))
-            .args(["run", "--config"])
-            .arg(config)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(output)
-            .spawn()
-            .unwrap(),
-        parsed.data.path.join("runtime/child.lease"),
-        digest,
-    )
+    Command::new(env!("CARGO_BIN_EXE_ocd"))
+        .args(["run", "--config"])
+        .arg(config)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(output)
+        .spawn()
+        .unwrap()
 }
 
 pub(crate) async fn ready(client: &Client, admin: SocketAddr, child: &mut Process) {
     let deadline = Instant::now() + Duration::from_secs(45);
     loop {
-        assert!(
-            child.0.try_wait().unwrap().is_none(),
-            "ocd exited before readiness"
-        );
+        if let Some(status) = child.0.try_wait().unwrap() {
+            panic!("ocd exited before readiness: {status}");
+        }
         if response(client, admin, "/health/ready", "GET")
             .await
             .is_ok_and(|r| r.status() == 200)

--- a/crates/service/tests/workflow_support/process_crash.rs
+++ b/crates/service/tests/workflow_support/process_crash.rs
@@ -89,8 +89,8 @@ async fn workflow_ocd_sigkill_after_step_commit_replays_without_callback() {
     let client: Client =
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
             .build_http();
-    let mut first = spawn(&config, &log);
-    ready(&client, admin, &mut first).await;
+    let mut process = spawn(&config, &log);
+    ready(&client, admin, &mut process).await;
     let create = tenant_json(&client, public, "/create/crash-instance").await;
     assert_eq!(create["id"], "crash-instance", "{create}");
     let connection = rusqlite::Connection::open_with_flags(
@@ -105,22 +105,21 @@ async fn workflow_ocd_sigkill_after_step_commit_replays_without_callback() {
         if let Some(output) = output {
             break output;
         }
-        assert!(first.0.try_wait().unwrap().is_none());
+        assert!(process.0.try_wait().unwrap().is_none());
         assert!(Instant::now() < deadline, "first step did not commit");
         tokio::time::sleep(Duration::from_millis(20)).await;
     };
-    first.0.kill().unwrap();
-    assert!(!first.0.wait().unwrap().success());
-    drop(first);
-    let mut second = spawn(&config, &log);
-    ready(&client, admin, &mut second).await;
+    process.0.kill().unwrap();
+    assert!(!process.0.wait().unwrap().success());
+    process.restart(&config, &log);
+    ready(&client, admin, &mut process).await;
     let deadline = Instant::now() + Duration::from_secs(45);
     let status = loop {
         let status = tenant_json(&client, public, "/status/crash-instance").await;
         if status["status"] == "complete" {
             break status;
         }
-        assert!(second.0.try_wait().unwrap().is_none());
+        assert!(process.0.try_wait().unwrap().is_none());
         assert!(
             Instant::now() < deadline,
             "replay did not complete: {status}"
@@ -145,14 +144,14 @@ async fn workflow_ocd_sigkill_after_step_commit_replays_without_callback() {
     );
     assert!(
         Command::new("/bin/kill")
-            .args(["-TERM", &second.0.id().to_string()])
+            .args(["-TERM", &process.0.id().to_string()])
             .status()
             .unwrap()
             .success()
     );
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
-        if let Some(exit) = second.0.try_wait().unwrap() {
+        if let Some(exit) = process.0.try_wait().unwrap() {
             assert!(exit.success());
             break;
         }

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -1,6 +1,6 @@
 # 首次发行 0.1.0 验收
 
-日期：2026-09-05。状态：准备中；尚未创建 `v0.1.0`，尚无公开 Release。
+日期：2026-09-05。状态：`v0.1.0` 已创建；发布验证失败，尚无公开 Release。
 
 ## 固定输入与范围
 
@@ -55,7 +55,20 @@ PR CI `33951624671` 的产品 Gates 通过，但 `p3-contract` 的 source baseli
 - [x] GitHub API 回读：main required `ci`（包含管理员，禁止 force push/delete）；release environment
   仅接受 `v*` tag；`Release tags` ruleset `22323316` 限制 tag 创建/更新/删除，只有 repository admin
   maintainer 可 bypass；默认 token read-only；immutable releases 已启用。
-- [ ] [发布 PR #5](https://github.com/elliothux/open-compute/pull/5)、main CI、annotated tag commit 和 release workflow URL。
+- [x] [发布 PR #5](https://github.com/elliothux/open-compute/pull/5) 已合入 main，源码
+  `203d0470dccdd5bd5961660bbc580b2c286e0324`；[main CI](https://github.com/elliothux/open-compute/actions/runs/33955854993) 全部通过。
+  annotated `v0.1.0` 指向该 commit，tag object `bdddb46e4800927837459c211db28845fbbb8386`。
+- [发布运行](https://github.com/elliothux/open-compute/actions/runs/33957020994) 的 MSRV 与 Linux/macOS
+  静态检查通过；macOS coverage 在 P2 exit Gate 报告 `ocd exited before readiness`，后续 Gate、
+  packaging 与 publish 均未执行。未生成通过 coverage 门槛的证据，也未发布 assets。
+- 排查发现共享进程夹具用新的 `Process` 替换旧对象时，先 spawn 新 daemon，再运行旧 guard 的
+  orphan cleanup，二者竞争同一 child lease。本地旧夹具复现 `RUNTIME_INVALID`；修复为同一 guard
+  跨代持有进程，仅替换已退出的 Child，生产 daemon 自行完成 orphan recovery。
+  相关 P2、Workflow crash、Wrangler restart 入口统一采用该所有权模型。
+  修复后的本地插桩 P2 运行通过启动/重启阶段，在后续步骤因本机磁盘水位返回 `DO_STORAGE_LIMIT`；
+  报告保留于 `.temp/gate-run/failed/20260905T173937-14b7a082/report.json`，不能记为 Gate 通过。
+  CI 原记录没有子进程 stderr，因此竞态与 CI 启动退出之间仍需托管运行验证；失败 artifact
+  补充只收集保留的 `ocd.log`，不上传 fixture 数据库、配置或凭据。
 - GitHub 托管 runner 的特权 egress 操作已获用户明确授权；本机不运行 sudo。
 - [ ] Linux/macOS 单轮 Gate、90% coverage、Linux 特权 egress 及清理结果。
 - [ ] 四平台 package report、单文件隔离/首启/重启/损坏拒绝、六个 assets 的回读校验。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "1e7c077f82b0bba957c04e3884497092af8b01a429dfc180b915c6b6ed52e3e0",
+  "openComputeRevision": "e4e4c44bad4d782561b614f270f84cb06dae9d81b3623618e55cf5010e90e106",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {


### PR DESCRIPTION
## Problem and change

Replacing the shared Process guard after a crash spawns the new daemon before dropping the old guard. Both can recover the same workerd lease, producing startup exits or RUNTIME_INVALID during cleanup. Keep one guard across restarts and replace only its already-exited Child; production ocd retains responsibility for orphan recovery. Apply this to P2, Workflow crash replay, and Wrangler restart Gates.

Readiness failures now include the process exit status. CI failure artifacts include retained ocd logs, without collecting fixture databases, configuration, or credentials. Update first-release evidence and the current conformance source baseline.

## Validation

- Runtime build, fmt, workspace Clippy, no-default-features, MSRV, metadata, dependency boundaries, production hygiene, and baseline identity checked locally.
- Original instrumented P2 reproduced orphan cleanup RUNTIME_INVALID. After the fix, instrumented P2 progressed past restart and failed later with DO_STORAGE_LIMIT on the nearly full local disk. This is not a passing Gate; retained report: .temp/gate-run/failed/20260905T173937-14b7a082/report.json.
- After user-authorized Rust cache cleanup restored 69 GiB free space, the same instrumented P2 Gate passed all crash/restart transitions in 125.30 seconds (one round; inventory verified). Report: .temp/gate-run/20260905T174554-9ee5c0e4/report.json. The failed runs remain retained.
- The related instrumented workflow-recovery and p6-wrangler-resources Gates also passed in one round; report: .temp/gate-run/20260905T174821-370f3aef/report.json.
- Hosted CI and release qualification remain required. The existing v0.1.0 tag is unchanged and no release assets have been published.
