### PR TITLE
fix(r2): include responsive multipart uploads in 0.1.0

### DIFF
--- a/crates/artifacts/src/lib.rs
+++ b/crates/artifacts/src/lib.rs
@@ -42,8 +42,8 @@ pub use r2_model::{
     R2_MAX_MULTIPART_OBJECT_BYTES, R2_MAX_MULTIPART_PART_BYTES, R2_MAX_MULTIPART_PARTS,
     R2_MIN_MULTIPART_PART_BYTES, R2BucketIdentity, R2BucketLocator, R2ChecksumAlgorithm,
     R2Checksums, R2ComputedChecksums, R2Condition, R2Download, R2EtagMatch, R2GetResult,
-    R2HttpMetadata, R2MultipartCreateOptions, R2ObjectMetadata, R2PutOptions, R2Range, R2SsecKey,
-    R2StorageClass, R2UploadSource, R2UploadedPart, UserObjectKey,
+    R2HttpMetadata, R2MultipartCreateOptions, R2ObjectMetadata, R2PartSource, R2PutOptions,
+    R2Range, R2SsecKey, R2StorageClass, R2UploadSource, R2UploadedPart, UserObjectKey,
 };
 pub use r2_preflight::{R2PreflightOutcome, preflight_r2};
 pub use snapshot::{CommittedSnapshot, IncompleteSnapshotCleanup, SnapshotObjectStore};

--- a/crates/artifacts/src/local_tests.rs
+++ b/crates/artifacts/src/local_tests.rs
@@ -802,17 +802,15 @@ async fn local_typed_r2_round_trips_metadata_conditions_ssec_and_multipart() {
         .unwrap();
     let part_path = fixture.config.path.parent().unwrap().join("r2-part");
     write_private(&part_path, b"multipart-local");
-    let part_source = R2UploadSource {
+    let part_source = crate::R2PartSource {
         path: part_path,
         length: 15,
-        checksums: hash_bytes(b"multipart-local"),
-        version: version.clone(),
     };
     let part = store
         .upload_part(&locator, &multipart_key, &upload_id, 1, &part_source, None)
         .await
         .unwrap();
-    assert_eq!(part.etag, hex::encode(part_source.checksums.md5));
+    assert_eq!(part.etag, hex::encode(md5::Md5::digest(b"multipart-local")));
     let part_digest = hex::decode(&part.etag).unwrap();
     let expected_complete_etag = format!("{}-1", hex::encode(md5::Md5::digest(part_digest)));
     let completed = store

--- a/crates/artifacts/src/mock_s3.rs
+++ b/crates/artifacts/src/mock_s3.rs
@@ -561,7 +561,7 @@ async fn handle_conn(
                 part_digests.extend_from_slice(&md5::Md5::digest(&part));
                 assembled.extend_from_slice(&part);
             }
-            let checksums = crate::hash_bytes(&assembled);
+            let sha256 = hex::encode(Sha256::digest(&assembled));
             let metadata = upload.metadata;
             let etag = format!(
                 "{}-{part_count}",
@@ -571,7 +571,7 @@ async fn handle_conn(
                 state.lock().expect("lock").objects.insert(
                     key.clone(),
                     StoredObject {
-                        sha256: hex::encode(checksums.sha256),
+                        sha256,
                         body: assembled,
                         etag: etag.clone(),
                         metadata: metadata.clone(),
@@ -587,7 +587,7 @@ async fn handle_conn(
             state.lock().expect("lock").objects.insert(
                 key.clone(),
                 StoredObject {
-                    sha256: hex::encode(checksums.sha256),
+                    sha256,
                     body: assembled,
                     etag: etag.clone(),
                     metadata,

--- a/crates/artifacts/src/r2.rs
+++ b/crates/artifacts/src/r2.rs
@@ -5,9 +5,9 @@ use crate::backend::{
     ObjectRange, open_private_source,
 };
 use crate::r2_codec::{
-    META_CUSTOM, META_MD5, META_SCHEMA, META_SHA1, META_SHA256, META_SHA384, META_SHA512,
-    META_SSEC_MD5, META_STORAGE, META_VERSION, OBJECTS_SUFFIX, canonical_custom_metadata,
-    decode_metadata, encode_custom_metadata, integrity_error,
+    META_CUSTOM, META_HTTP_FIELDS, META_MD5, META_SCHEMA, META_SHA1, META_SHA256, META_SHA384,
+    META_SHA512, META_SSEC_MD5, META_STORAGE, META_VERSION, OBJECTS_SUFFIX,
+    canonical_custom_metadata, decode_metadata, encode_custom_metadata, integrity_error,
 };
 use crate::r2_model::{
     R2_MAX_DELETE_KEYS, R2_MAX_LIST_LIMIT, R2BucketIdentity, R2BucketLocator, R2ChecksumAlgorithm,
@@ -409,12 +409,27 @@ pub fn hash_bytes(bytes: &[u8]) -> R2ComputedChecksums {
 pub(crate) fn create_user_metadata(
     version: &str,
     custom_metadata: &BTreeMap<String, String>,
+    http_metadata: &crate::R2HttpMetadata,
     storage_class: R2StorageClass,
     ssec: Option<&R2SsecKey>,
 ) -> Result<BTreeMap<String, String>, PlatformError> {
     let mut metadata = BTreeMap::new();
     metadata.insert(META_SCHEMA.to_owned(), "1".to_owned());
     metadata.insert(META_VERSION.to_owned(), version.to_owned());
+    let fields = [
+        http_metadata.content_type.is_some(),
+        http_metadata.content_language.is_some(),
+        http_metadata.content_disposition.is_some(),
+        http_metadata.content_encoding.is_some(),
+        http_metadata.cache_control.is_some(),
+        http_metadata.cache_expiry.is_some(),
+    ]
+    .into_iter()
+    .enumerate()
+    .fold(0_u8, |mask, (bit, present)| {
+        mask | (u8::from(present) << bit)
+    });
+    metadata.insert(META_HTTP_FIELDS.to_owned(), fields.to_string());
     metadata.insert(
         META_CUSTOM.to_owned(),
         encode_custom_metadata(custom_metadata)?,
@@ -433,6 +448,7 @@ pub(crate) fn object_user_metadata(
     create_user_metadata(
         &source.version,
         &options.custom_metadata,
+        &options.http_metadata,
         options.storage_class,
         options.ssec.as_ref(),
     )

--- a/crates/artifacts/src/r2_codec.rs
+++ b/crates/artifacts/src/r2_codec.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 pub(crate) const META_SCHEMA: &str = "oc-r2-schema";
 pub(crate) const META_VERSION: &str = "oc-r2-version";
 pub(crate) const META_CUSTOM: &str = "oc-r2-custom";
+pub(crate) const META_HTTP_FIELDS: &str = "oc-r2-http-fields";
 pub(crate) const META_MD5: &str = "oc-r2-md5";
 pub(crate) const META_SHA1: &str = "oc-r2-sha1";
 pub(crate) const META_SHA256: &str = "oc-r2-sha256";
@@ -67,6 +68,11 @@ pub(crate) fn decode_metadata(
     if canonical_custom_metadata(&custom_metadata).map_err(|_| integrity_error())? != custom_bytes {
         return Err(integrity_error());
     }
+    let raw_fields = metadata.get(META_HTTP_FIELDS).ok_or_else(integrity_error)?;
+    let fields: u8 = raw_fields.parse().map_err(|_| integrity_error())?;
+    if fields > 63 || fields.to_string() != *raw_fields {
+        return Err(integrity_error());
+    }
     let checksums = R2Checksums {
         md5: hex_checksum(metadata.get(META_MD5), 32)?,
         sha1: hex_checksum(metadata.get(META_SHA1), 40)?,
@@ -103,12 +109,12 @@ pub(crate) fn decode_metadata(
         http_etag,
         uploaded: object.last_modified_ms,
         http_metadata: Some(R2HttpMetadata {
-            content_type: object.http.content_type.clone(),
-            content_language: object.http.content_language.clone(),
-            content_disposition: object.http.content_disposition.clone(),
-            content_encoding: object.http.content_encoding.clone(),
-            cache_control: object.http.cache_control.clone(),
-            cache_expiry: object.http.cache_expiry,
+            content_type: declared_http_field(fields, 1, &object.http.content_type)?,
+            content_language: declared_http_field(fields, 2, &object.http.content_language)?,
+            content_disposition: declared_http_field(fields, 4, &object.http.content_disposition)?,
+            content_encoding: declared_http_field(fields, 8, &object.http.content_encoding)?,
+            cache_control: declared_http_field(fields, 16, &object.http.cache_control)?,
+            cache_expiry: declared_http_field(fields, 32, &object.http.cache_expiry)?,
         }),
         custom_metadata: Some(custom_metadata),
         range,
@@ -116,6 +122,20 @@ pub(crate) fn decode_metadata(
         storage_class: storage_class.to_owned(),
         ssec_key_md5,
     })
+}
+
+// S3 providers may synthesize headers such as Content-Type. Only tenant-declared
+// fields belong to the R2 object; a missing declared field is still corruption.
+fn declared_http_field<T: Clone>(
+    fields: u8,
+    bit: u8,
+    value: &Option<T>,
+) -> Result<Option<T>, PlatformError> {
+    if fields & bit == 0 {
+        Ok(None)
+    } else {
+        value.clone().map(Some).ok_or_else(integrity_error)
+    }
 }
 
 fn hex_checksum(value: Option<&String>, len: usize) -> Result<Option<String>, PlatformError> {

--- a/crates/artifacts/src/r2_model.rs
+++ b/crates/artifacts/src/r2_model.rs
@@ -428,7 +428,16 @@ pub struct R2UploadedPart {
     pub etag: String,
 }
 
-/// Secure, replayable local file prepared before PUT or `UploadPart`.
+/// Secure, replayable local file prepared before `UploadPart`.
+#[derive(Debug)]
+pub struct R2PartSource {
+    /// Owned staging path opened and validated by the typed store.
+    pub path: PathBuf,
+    /// Exact byte length; the backend computes its required transfer checksum.
+    pub length: u64,
+}
+
+/// Secure, replayable local file and object metadata prepared before PUT.
 #[derive(Debug)]
 pub struct R2UploadSource {
     /// Owned staging path opened by the typed store.

--- a/crates/artifacts/src/r2_multipart.rs
+++ b/crates/artifacts/src/r2_multipart.rs
@@ -10,7 +10,7 @@ use crate::r2::{
 };
 use crate::r2_codec::integrity_error;
 use crate::r2_model::{
-    R2BucketLocator, R2MultipartCreateOptions, R2ObjectMetadata, R2SsecKey, R2UploadSource,
+    R2BucketLocator, R2MultipartCreateOptions, R2ObjectMetadata, R2PartSource, R2SsecKey,
     R2UploadedPart, UserObjectKey, invalid_options,
 };
 use open_compute_core::PlatformError;
@@ -39,6 +39,7 @@ impl R2ObjectStore {
         let user = create_user_metadata(
             version,
             &options.custom_metadata,
+            &options.http_metadata,
             options.storage_class,
             options.ssec.as_ref(),
         )?;
@@ -76,7 +77,7 @@ impl R2ObjectStore {
         key: &UserObjectKey,
         provider_upload_id: &str,
         part_number: i32,
-        source: &R2UploadSource,
+        source: &R2PartSource,
         ssec: Option<&R2SsecKey>,
     ) -> Result<R2UploadedPart, PlatformError> {
         if !(1..=crate::r2_model::R2_MAX_MULTIPART_PARTS).contains(&part_number)

--- a/crates/artifacts/src/r2_tests.rs
+++ b/crates/artifacts/src/r2_tests.rs
@@ -9,6 +9,9 @@ use open_compute_core::PlatformId;
 use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt as _;
 
+#[path = "r2_tests/http_metadata.rs"]
+mod http_metadata;
+
 fn locator() -> R2BucketLocator {
     let resource_id = ResourceId::generate();
     let physical_prefix = format!("tenant/r2/v1/{resource_id}/");

--- a/crates/artifacts/src/r2_tests/http_metadata.rs
+++ b/crates/artifacts/src/r2_tests/http_metadata.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn http_metadata_preserves_absence_and_rejects_lost_declared_headers() {
+    let provider = crate::ObjectHttpMetadata {
+        content_type: Some("application/octet-stream".to_owned()),
+        content_language: Some("en".to_owned()),
+        content_disposition: Some("attachment".to_owned()),
+        content_encoding: Some("identity".to_owned()),
+        cache_control: Some("max-age=60".to_owned()),
+        cache_expiry: Some(1_000),
+    };
+    for fields in 0..64 {
+        let declared = R2HttpMetadata {
+            content_type: (fields & 1 != 0)
+                .then(|| provider.content_type.clone())
+                .flatten(),
+            content_language: (fields & 2 != 0)
+                .then(|| provider.content_language.clone())
+                .flatten(),
+            content_disposition: (fields & 4 != 0)
+                .then(|| provider.content_disposition.clone())
+                .flatten(),
+            content_encoding: (fields & 8 != 0)
+                .then(|| provider.content_encoding.clone())
+                .flatten(),
+            cache_control: (fields & 16 != 0)
+                .then(|| provider.cache_control.clone())
+                .flatten(),
+            cache_expiry: (fields & 32 != 0)
+                .then_some(provider.cache_expiry)
+                .flatten(),
+        };
+        let mut object = ObjectMetadata {
+            user: create_user_metadata(
+                &uuid::Uuid::now_v7().to_string(),
+                &BTreeMap::new(),
+                &declared,
+                R2StorageClass::Standard,
+                None,
+            )
+            .unwrap(),
+            http: provider.clone(),
+            etag: "etag".to_owned(),
+            ..ObjectMetadata::default()
+        };
+        assert_eq!(
+            decode_metadata("key", &object, None).unwrap().http_metadata,
+            Some(declared)
+        );
+        if fields != 0 {
+            object.http = crate::ObjectHttpMetadata::default();
+            assert!(decode_metadata("key", &object, None).is_err());
+        }
+        for invalid in ["", "01", "64", "-1", "256", "invalid"] {
+            object
+                .user
+                .insert(META_HTTP_FIELDS.to_owned(), invalid.to_owned());
+            assert!(decode_metadata("key", &object, None).is_err());
+        }
+        object.user.remove(META_HTTP_FIELDS);
+        assert!(
+            decode_metadata("key", &object, None).is_err(),
+            "missing authority is not backfilled"
+        );
+    }
+}

--- a/crates/artifacts/src/r2_tests/provider_multipart.rs
+++ b/crates/artifacts/src/r2_tests/provider_multipart.rs
@@ -149,13 +149,17 @@ async fn typed_store_round_trips_ssec_storage_class_and_multipart() {
     );
     let part_path = temp.path().join("part");
     std::fs::write(&part_path, b"part-body").unwrap();
+    std::fs::set_permissions(&part_path, std::fs::Permissions::from_mode(0o600)).unwrap();
     let part = store
         .upload_part(
             &locator,
             &mpu_key,
             &upload_id,
             1,
-            &upload_source(part_path, b"part-body"),
+            &crate::R2PartSource {
+                path: part_path,
+                length: 9,
+            },
             None,
         )
         .await

--- a/crates/service/src/r2_backend.rs
+++ b/crates/service/src/r2_backend.rs
@@ -4,6 +4,8 @@
 pub(crate) mod multipart;
 #[path = "r2_backend_objects.rs"]
 pub(crate) mod objects;
+#[path = "r2_backend_staging.rs"]
+mod staging;
 
 use crate::metrics::{
     MetricsRegistry, R2Operation, R2ProviderError, R2StreamDirection, R2StreamGuard,
@@ -45,6 +47,7 @@ pub struct R2BindingService {
     uploads: OperationGate,
     downloads: OperationGate,
     staging_bytes: Arc<AtomicU64>,
+    checksums: Arc<tokio::sync::Semaphore>,
     metrics: Option<Arc<MetricsRegistry>>,
 }
 
@@ -72,6 +75,9 @@ impl R2BindingService {
             uploads: OperationGate::new(config.max_concurrent_uploads),
             downloads: OperationGate::new(config.max_concurrent_downloads),
             staging_bytes: Arc::new(AtomicU64::new(0)),
+            checksums: Arc::new(tokio::sync::Semaphore::new(
+                config.max_concurrent_uploads.max(1) as usize,
+            )),
             metrics: None,
             config,
             staging,
@@ -628,124 +634,6 @@ impl R2BindingService {
                 Err(error)
             }
         }
-    }
-
-    async fn stage_management_put(
-        &self,
-        resource: ResourceId,
-        request_id: &str,
-        key: &str,
-        max_object_bytes: u64,
-        body: Body,
-    ) -> Result<StagedPut, PlatformError> {
-        use futures::TryStreamExt as _;
-        let mut stream = body.into_data_stream();
-        let (path, file) = self.staging.create(resource, request_id)?;
-        let mut file = tokio::fs::File::from_std(file);
-        let guard = StagingFile::new(path);
-        let mut length = 0_u64;
-        let mut reservation = StagingReservation::new(
-            self.staging_bytes.clone(),
-            self.config.max_staging_bytes,
-            self.metrics.clone(),
-        );
-        while let Some(chunk) = stream.try_next().await.map_err(|_| protocol_error())? {
-            let added = u64::try_from(chunk.len()).map_err(|_| object_too_large())?;
-            length = length.checked_add(added).ok_or_else(object_too_large)?;
-            if length > max_object_bytes {
-                return Err(object_too_large());
-            }
-            reservation.add(added)?;
-            ensure_storage_headroom(&self.storage, added)?;
-            file.write_all(&chunk).await.map_err(|_| overloaded())?;
-        }
-        file.sync_all().await.map_err(|_| overloaded())?;
-        drop(file);
-        let checksums = hash_file(&guard.path, length)?;
-        Ok(StagedPut {
-            header: PutHeader {
-                key: key.to_owned(),
-                options: PutWireOptions::default(),
-            },
-            length,
-            checksums,
-            guard,
-            _reservation: reservation,
-        })
-    }
-
-    async fn stage_put(
-        &self,
-        resource: ResourceId,
-        request_id: &str,
-        max_object_bytes: u64,
-        body: Body,
-    ) -> Result<StagedPut, PlatformError> {
-        use futures::TryStreamExt as _;
-        let mut stream = body.into_data_stream();
-        let mut header_bytes = Vec::with_capacity(4096);
-        let mut header_end = None;
-        let mut header = None;
-        let mut staged = None;
-        let mut length = 0_u64;
-        let mut reservation = StagingReservation::new(
-            self.staging_bytes.clone(),
-            self.config.max_staging_bytes,
-            self.metrics.clone(),
-        );
-        while let Some(chunk) = stream.try_next().await.map_err(|_| protocol_error())? {
-            let mut remaining = chunk.as_ref();
-            while !remaining.is_empty() {
-                if header.is_none() {
-                    let needed =
-                        header_end.map_or(4, |end: usize| end.saturating_sub(header_bytes.len()));
-                    let take = needed.min(remaining.len());
-                    header_bytes.extend_from_slice(&remaining[..take]);
-                    remaining = &remaining[take..];
-                    if header_end.is_none() && header_bytes.len() == 4 {
-                        let size = u32::from_be_bytes(
-                            header_bytes[..4].try_into().map_err(|_| protocol_error())?,
-                        );
-                        let size = usize::try_from(size).map_err(|_| protocol_error())?;
-                        if size > MAX_METADATA_BYTES {
-                            return Err(metadata_too_large());
-                        }
-                        header_end = Some(4_usize.checked_add(size).ok_or_else(protocol_error)?);
-                    }
-                    if header_end.is_some_and(|end| end == header_bytes.len()) {
-                        let parsed: PutHeader = parse_json(&header_bytes[4..])?;
-                        parsed.options.validate()?;
-                        let (path, file) = self.staging.create(resource, request_id)?;
-                        let file = tokio::fs::File::from_std(file);
-                        staged = Some((StagingFile::new(path), file));
-                        header = Some(parsed);
-                    }
-                    continue;
-                }
-                let added = u64::try_from(remaining.len()).map_err(|_| object_too_large())?;
-                length = length.checked_add(added).ok_or_else(object_too_large)?;
-                if length > max_object_bytes {
-                    return Err(object_too_large());
-                }
-                reservation.add(added)?;
-                ensure_storage_headroom(&self.storage, added)?;
-                let (_, file) = staged.as_mut().ok_or_else(protocol_error)?;
-                file.write_all(remaining).await.map_err(|_| overloaded())?;
-                remaining = &[];
-            }
-        }
-        let header = header.ok_or_else(protocol_error)?;
-        let (guard, file) = staged.ok_or_else(protocol_error)?;
-        file.sync_all().await.map_err(|_| overloaded())?;
-        drop(file);
-        let checksums = hash_file(&guard.path, length)?;
-        Ok(StagedPut {
-            header,
-            length,
-            checksums,
-            guard,
-            _reservation: reservation,
-        })
     }
 
     async fn list(

--- a/crates/service/src/r2_backend_multipart.rs
+++ b/crates/service/src/r2_backend_multipart.rs
@@ -220,11 +220,9 @@ impl R2BindingService {
                 "R2 SSE-C key is invalid or does not match the object",
             ));
         }
-        let source = R2UploadSource {
+        let source = open_compute_artifacts::R2PartSource {
             path: staged.guard.path.clone(),
             length: staged.length,
-            checksums: hash_file(&staged.guard.path, staged.length)?,
-            version: record.object_version.clone(),
         };
         let part = mutation_timeout_result(
             timeout,

--- a/crates/service/src/r2_backend_staging.rs
+++ b/crates/service/src/r2_backend_staging.rs
@@ -1,0 +1,146 @@
+//! Bounded staging and checksum work for R2 object PUTs.
+
+use super::*;
+
+impl R2BindingService {
+    pub(super) async fn stage_management_put(
+        &self,
+        resource: ResourceId,
+        request_id: &str,
+        key: &str,
+        max_object_bytes: u64,
+        body: Body,
+    ) -> Result<StagedPut, PlatformError> {
+        use futures::TryStreamExt as _;
+        let mut stream = body.into_data_stream();
+        let (path, file) = self.staging.create(resource, request_id)?;
+        let mut file = tokio::fs::File::from_std(file);
+        let guard = StagingFile::new(path);
+        let mut length = 0_u64;
+        let mut reservation = StagingReservation::new(
+            self.staging_bytes.clone(),
+            self.config.max_staging_bytes,
+            self.metrics.clone(),
+        );
+        while let Some(chunk) = stream.try_next().await.map_err(|_| protocol_error())? {
+            let added = u64::try_from(chunk.len()).map_err(|_| object_too_large())?;
+            length = length.checked_add(added).ok_or_else(object_too_large)?;
+            if length > max_object_bytes {
+                return Err(object_too_large());
+            }
+            reservation.add(added)?;
+            ensure_storage_headroom(&self.storage, added)?;
+            file.write_all(&chunk).await.map_err(|_| overloaded())?;
+        }
+        file.sync_all().await.map_err(|_| overloaded())?;
+        drop(file);
+        self.hash_staged_put(
+            PutHeader {
+                key: key.to_owned(),
+                options: PutWireOptions::default(),
+            },
+            length,
+            guard,
+            reservation,
+        )
+        .await
+    }
+
+    pub(super) async fn stage_put(
+        &self,
+        resource: ResourceId,
+        request_id: &str,
+        max_object_bytes: u64,
+        body: Body,
+    ) -> Result<StagedPut, PlatformError> {
+        use futures::TryStreamExt as _;
+        let mut stream = body.into_data_stream();
+        let mut header_bytes = Vec::with_capacity(4096);
+        let mut header_end = None;
+        let mut header = None;
+        let mut staged = None;
+        let mut length = 0_u64;
+        let mut reservation = StagingReservation::new(
+            self.staging_bytes.clone(),
+            self.config.max_staging_bytes,
+            self.metrics.clone(),
+        );
+        while let Some(chunk) = stream.try_next().await.map_err(|_| protocol_error())? {
+            let mut remaining = chunk.as_ref();
+            while !remaining.is_empty() {
+                if header.is_none() {
+                    let needed =
+                        header_end.map_or(4, |end: usize| end.saturating_sub(header_bytes.len()));
+                    let take = needed.min(remaining.len());
+                    header_bytes.extend_from_slice(&remaining[..take]);
+                    remaining = &remaining[take..];
+                    if header_end.is_none() && header_bytes.len() == 4 {
+                        let size = u32::from_be_bytes(
+                            header_bytes[..4].try_into().map_err(|_| protocol_error())?,
+                        );
+                        let size = usize::try_from(size).map_err(|_| protocol_error())?;
+                        if size > MAX_METADATA_BYTES {
+                            return Err(metadata_too_large());
+                        }
+                        header_end = Some(4_usize.checked_add(size).ok_or_else(protocol_error)?);
+                    }
+                    if header_end.is_some_and(|end| end == header_bytes.len()) {
+                        let parsed: PutHeader = parse_json(&header_bytes[4..])?;
+                        parsed.options.validate()?;
+                        let (path, file) = self.staging.create(resource, request_id)?;
+                        let file = tokio::fs::File::from_std(file);
+                        staged = Some((StagingFile::new(path), file));
+                        header = Some(parsed);
+                    }
+                    continue;
+                }
+                let added = u64::try_from(remaining.len()).map_err(|_| object_too_large())?;
+                length = length.checked_add(added).ok_or_else(object_too_large)?;
+                if length > max_object_bytes {
+                    return Err(object_too_large());
+                }
+                reservation.add(added)?;
+                ensure_storage_headroom(&self.storage, added)?;
+                let (_, file) = staged.as_mut().ok_or_else(protocol_error)?;
+                file.write_all(remaining).await.map_err(|_| overloaded())?;
+                remaining = &[];
+            }
+        }
+        let header = header.ok_or_else(protocol_error)?;
+        let (guard, file) = staged.ok_or_else(protocol_error)?;
+        file.sync_all().await.map_err(|_| overloaded())?;
+        drop(file);
+        self.hash_staged_put(header, length, guard, reservation)
+            .await
+    }
+
+    pub(super) async fn hash_staged_put(
+        &self,
+        header: PutHeader,
+        length: u64,
+        guard: StagingFile,
+        reservation: StagingReservation,
+    ) -> Result<StagedPut, PlatformError> {
+        let permit = self
+            .checksums
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| overloaded())?;
+        // A started blocking task cannot be aborted. It owns both the staging
+        // reservation and its CPU permit until hashing (and cleanup) really ends.
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let checksums = hash_file(&guard.path, length)?;
+            Ok(StagedPut {
+                header,
+                length,
+                checksums,
+                guard,
+                _reservation: reservation,
+            })
+        })
+        .await
+        .map_err(|_| overloaded())?
+    }
+}

--- a/crates/service/src/r2_backend_tests.rs
+++ b/crates/service/src/r2_backend_tests.rs
@@ -896,3 +896,6 @@ async fn object_authority_reconciles_every_current_put_and_delete_observation() 
 
 #[path = "r2_backend_tests/multipart.rs"]
 mod multipart_tests;
+
+#[path = "r2_backend_tests/staging.rs"]
+mod staging_tests;

--- a/crates/service/src/r2_backend_tests/multipart.rs
+++ b/crates/service/src/r2_backend_tests/multipart.rs
@@ -1,5 +1,110 @@
 use super::*;
 
+#[tokio::test]
+async fn cancelled_and_timed_out_part_streams_release_admission_without_publishing() {
+    use futures::StreamExt as _;
+    let fixture = fixture().await;
+    let created = fixture
+        .service
+        .handle(request(
+            &fixture,
+            "createMultipartUpload",
+            JSON_CONTENT_TYPE,
+            Body::from(r#"{"key":"interrupted","options":{}}"#),
+        ))
+        .await;
+    assert_eq!(created.status(), StatusCode::OK);
+    let created = body_json(created).await;
+    let upload_id = created["uploadId"].as_str().unwrap();
+    for cancel in [true, false] {
+        let frame = to_bytes(
+            part_frame("interrupted", upload_id, 1, b"unfinished", None),
+            1024,
+        )
+        .await
+        .unwrap();
+        let stream = futures::stream::once(async move { Ok::<_, std::io::Error>(frame) })
+            .chain(futures::stream::pending());
+        let mut pending = Box::pin(fixture.service.handle(request(
+            &fixture,
+            "uploadPart",
+            FRAME_CONTENT_TYPE,
+            Body::from_stream(stream),
+        )));
+        if cancel {
+            tokio::select! {
+                _ = &mut pending => panic!("stream ended before cancellation"),
+                () = async {
+                    tokio::time::timeout(Duration::from_secs(2), async {
+                        while fixture.service.staging_bytes.load(Ordering::Acquire) == 0 {
+                            tokio::task::yield_now().await;
+                        }
+                    }).await.unwrap();
+                } => {}
+            }
+            drop(pending);
+        } else {
+            let response = pending.await;
+            assert_eq!(
+                response.headers().get(ERROR_HEADER).unwrap(),
+                ErrorCode::R2ProviderUnavailable.as_str()
+            );
+        }
+        assert_eq!(fixture.service.staging_bytes.load(Ordering::Acquire), 0);
+        assert_eq!(fixture.pins.count(fixture.resource), 0);
+        assert!(
+            std::fs::read_dir(fixture.storage.data_dir().root().join("r2-staging"))
+                .unwrap()
+                .next()
+                .is_none()
+        );
+        let account = fixture.storage.identity().default_account_id;
+        assert!(
+            R2MultipartRepository::new(fixture.storage.db())
+                .list_parts(upload_id)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            R2ObjectRepository::new(fixture.storage.db())
+                .get(account, fixture.resource, "interrupted")
+                .unwrap()
+                .is_none()
+        );
+        let lease = fixture
+            .service
+            .uploads
+            .acquire(fixture.resource, Duration::from_millis(50))
+            .await
+            .unwrap();
+        drop(lease);
+    }
+    let aborted = fixture
+        .service
+        .handle(request(
+            &fixture,
+            "abortMultipartUpload",
+            JSON_CONTENT_TYPE,
+            Body::from(
+                serde_json::json!({"key": "interrupted", "uploadId": upload_id}).to_string(),
+            ),
+        ))
+        .await;
+    assert_eq!(aborted.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        R2MultipartRepository::new(fixture.storage.db())
+            .get(
+                fixture.storage.identity().default_account_id,
+                fixture.resource,
+                upload_id
+            )
+            .unwrap()
+            .unwrap()
+            .state,
+        R2MultipartState::Aborted
+    );
+}
+
 fn part_frame(
     key: &str,
     upload_id: &str,

--- a/crates/service/src/r2_backend_tests/staging.rs
+++ b/crates/service/src/r2_backend_tests/staging.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[test]
+fn cancelled_checksum_task_keeps_file_quota_and_cpu_slot_until_finished() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .max_blocking_threads(1)
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let fixture = fixture().await;
+        let service = &fixture.service;
+        let slots = service.checksums.available_permits();
+        let (path, mut file) = service
+            .staging
+            .create(fixture.resource, &uuid::Uuid::now_v7().to_string())
+            .unwrap();
+        std::io::Write::write_all(&mut file, b"checksum").unwrap();
+        drop(file);
+        let mut reservation = StagingReservation::new(service.staging_bytes.clone(), 1024, None);
+        reservation.add(8).unwrap();
+        let (release, blocked) = std::sync::mpsc::channel();
+        let (started, ready) = tokio::sync::oneshot::channel();
+        let blocker = tokio::task::spawn_blocking(move || {
+            started.send(()).unwrap();
+            blocked.recv().unwrap();
+        });
+        ready.await.unwrap();
+        let mut hashing = Box::pin(service.hash_staged_put(
+            PutHeader {
+                key: "checksum".to_owned(),
+                options: PutWireOptions::default(),
+            },
+            8,
+            StagingFile::new(path.clone()),
+            reservation,
+        ));
+        assert!(futures::poll!(&mut hashing).is_pending());
+        drop(hashing);
+        assert!(path.exists());
+        assert_eq!(service.staging_bytes.load(Ordering::Acquire), 8);
+        assert_eq!(service.checksums.available_permits(), slots - 1);
+        // The async scheduler is still usable while the CPU worker is unavailable.
+        tokio::task::yield_now().await;
+        release.send(()).unwrap();
+        blocker.await.unwrap();
+        // One blocking worker makes this a deterministic drain barrier for the queued hash.
+        tokio::task::spawn_blocking(|| {}).await.unwrap();
+        assert!(!path.exists());
+        assert_eq!(service.staging_bytes.load(Ordering::Acquire), 0);
+        assert_eq!(service.checksums.available_permits(), slots);
+    });
+}
+
+#[tokio::test]
+async fn checksum_failure_releases_staging_and_permit() {
+    let fixture = fixture().await;
+    let service = &fixture.service;
+    let (path, file) = service
+        .staging
+        .create(fixture.resource, &uuid::Uuid::now_v7().to_string())
+        .unwrap();
+    drop(file);
+    let mut reservation = StagingReservation::new(service.staging_bytes.clone(), 1024, None);
+    reservation.add(1).unwrap();
+    let slots = service.checksums.available_permits();
+    let result = service
+        .hash_staged_put(
+            PutHeader {
+                key: "invalid".to_owned(),
+                options: PutWireOptions::default(),
+            },
+            1,
+            StagingFile::new(path.clone()),
+            reservation,
+        )
+        .await;
+    assert_eq!(
+        result.err().unwrap().code(),
+        ErrorCode::R2ObjectMetadataInvalid
+    );
+    assert!(!path.exists());
+    assert_eq!(service.staging_bytes.load(Ordering::Acquire), 0);
+    assert_eq!(service.checksums.available_permits(), slots);
+}

--- a/crates/service/tests/p0_5_r2_gate.rs
+++ b/crates/service/tests/p0_5_r2_gate.rs
@@ -2,6 +2,11 @@
 
 #![cfg(feature = "test-support")]
 
+#[path = "p0_5_r2_support/mod.rs"]
+mod support;
+#[path = "p0_5_r2_support/uploads.rs"]
+mod uploads;
+
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, header};
 use open_compute_artifacts::{
@@ -40,132 +45,25 @@ use std::time::{Duration, Instant};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn p0_5_real_r2_facade_matrix() {
-    let workerd = std::env::var_os("OPEN_COMPUTE_TEST_WORKERD")
-        .map(PathBuf::from)
-        .expect("OPEN_COMPUTE_TEST_WORKERD must name the verified stock runtime");
-    let root = repo_root();
-    let lock = root.join("packages/runtime/workerd.lock.json");
-    let assets = root.join("packages/runtime");
-    let temp = tempfile::tempdir().unwrap();
-    let storage = Arc::new(
-        PlatformStorage::bootstrap(&storage_config(&temp.path().join("data")), &SystemClock)
-            .unwrap(),
-    );
-    let mock = MockS3::spawn("open-compute").await;
-    let (artifacts, objects) = stores(&mock);
-    let runtime = verify_runtime_binary(&lock, &workerd, Duration::from_secs(10), &Redactor::new())
-        .await
-        .expect("formal pinned runtime");
-
-    let source_auth = GenerationAuthRegistry::new();
-    let binding_auth = GenerationAuthRegistry::new();
-    let source_listener = bind_runtime_source().await.unwrap();
-    let source_addr = source_listener.local_addr().unwrap();
-    let binding_listener = bind_binding_backend().await.unwrap();
-    let binding_addr = binding_listener.local_addr().unwrap();
-    let pins = ResourcePins::new();
     let r2_config = R2Config {
         max_object_bytes: 8 * 1024 * 1024,
         max_staging_bytes: 16 * 1024 * 1024,
         operation_timeout_ms: 5_000,
         ..R2Config::default()
     };
-    let r2_service = Arc::new(
-        R2BindingService::new(
-            storage.clone(),
-            pins.clone(),
-            objects.clone(),
-            r2_config.clone(),
-        )
-        .unwrap(),
-    );
-    let (shutdown_tx, mut source_shutdown) = tokio::sync::watch::channel(false);
-    let mut binding_shutdown = shutdown_tx.subscribe();
-    let source_task = tokio::spawn({
-        let source =
-            RuntimeSource::new(storage.clone(), artifacts.clone(), BundleLimits::default());
-        let auth = source_auth.clone();
-        async move {
-            serve_runtime_source(source_listener, source, auth, async move {
-                let _ = source_shutdown.changed().await;
-            })
-            .await
-        }
-    });
-    let binding_task = tokio::spawn({
-        let binding_storage = storage.clone();
-        let executor_storage = storage.clone();
-        let auth = binding_auth.clone();
-        let pins = pins.clone();
-        async move {
-            serve_binding_backend(
-                binding_listener,
-                binding_storage,
-                auth,
-                pins,
-                Arc::new(SqliteKvBindingExecutor::new(
-                    executor_storage,
-                    Arc::new(SystemClock),
-                )),
-                None,
-                Some(r2_service),
-                None,
-                open_compute_core::DurableObjectsConfig::default(),
-                open_compute_core::QueuesConfig::default(),
-                open_compute_core::WorkflowsConfig::default(),
-                None,
-                async move {
-                    let _ = binding_shutdown.changed().await;
-                },
-            )
-            .await
-        }
-    });
-
-    let compiler = StaticConfigCompiler::new(
-        runtime.clone(),
-        lock.clone(),
-        assets,
-        storage.data_dir().runtime_dir(),
-        PlatformReleaseMeta {
-            version: "p0.5-gate".to_owned(),
-        },
-        Duration::from_secs(20),
-        Redactor::new(),
-    )
-    .with_generation_auth(source_auth.clone())
-    .with_binding_generation_auth(binding_auth.clone());
-    let supervisor_slot = Arc::new(Mutex::new(None));
-    let transport = WorkerdTransport::new(source_auth.clone(), supervisor_slot.clone())
-        .with_test_request_body_limit(32 * 1024 * 1024);
-    let do_storage = storage
-        .data_dir()
-        .prepare_durable_object_storage(
-            &storage.identity().platform_id.to_string(),
-            runtime.version_output(),
-        )
-        .unwrap();
-    let supervisor = Arc::new(WorkerdSupervisor::new(
-        WorkerdSupervisorOptions {
-            runtime,
-            compiler,
-            config: runtime_config(),
-            clock: Arc::new(SystemClock),
-            jitter: Arc::new(OsJitter),
-            redactor: Redactor::new(),
-            lease_path: Some(storage.data_dir().runtime_dir().join("p0-5-gate.lease")),
-        },
-        vec![
-            ExternalServiceAddress::loopback("runtime-source", source_addr).unwrap(),
-            ExternalServiceAddress::loopback("binding-backend", binding_addr).unwrap(),
-            ExternalServiceAddress::loopback("observability-backend", binding_addr).unwrap(),
-        ],
-        vec![DirectoryServicePath::local("do-storage", &do_storage).unwrap()],
-        vec![source_auth, binding_auth],
-    ));
-    *supervisor_slot.lock().unwrap() = Some(supervisor.clone());
-    supervisor.start();
-    wait_running(&supervisor, Duration::from_secs(30)).await;
+    let support::R2Gate {
+        _temp,
+        mock: _mock,
+        storage,
+        objects,
+        artifacts,
+        pins,
+        transport,
+        supervisor,
+        shutdown_tx,
+        source_task,
+        binding_task,
+    } = support::start(r2_config.clone(), None).await;
 
     let account = storage.identity().default_account_id;
     let resource = create_bucket(&storage, &objects, &r2_config, account).await;
@@ -735,7 +633,7 @@ async fn wait_pid_change(supervisor: &WorkerdSupervisor, old_pid: i32, timeout: 
     }
 }
 
-fn stores(mock: &MockS3) -> (ArtifactStore, R2ObjectStore) {
+fn stores(endpoint: &str) -> (ArtifactStore, R2ObjectStore) {
     let config = PlatformConfig::from_toml_str(&format!(
         r#"
 [data]
@@ -744,7 +642,7 @@ master_key_file = "/var/lib/open-compute/keys/master.key"
 
 [storage]
 backend = "s3"
-endpoint = "{}"
+endpoint = "{endpoint}"
 region = "us-east-1"
 bucket = "open-compute"
 force_path_style = true
@@ -756,8 +654,7 @@ max_retries = 1
 retry_backoff_ms = 10
 connect_timeout_ms = 500
 request_timeout_ms = 5000
-"#,
-        mock.endpoint
+"#
     ))
     .unwrap()
     .object_storage
@@ -771,7 +668,7 @@ request_timeout_ms = 5000
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         );
     let credentials = resolve_s3_credentials_with(&config, &env).unwrap();
-    let client = ObjectBackend::connect_s3(&config, &credentials, 64 * 1024 * 1024).unwrap();
+    let client = ObjectBackend::connect_s3(&config, &credentials, 256 * 1024 * 1024).unwrap();
     (
         ArtifactStore::new(client.clone()),
         R2ObjectStore::new(client),

--- a/crates/service/tests/p0_5_r2_support/mod.rs
+++ b/crates/service/tests/p0_5_r2_support/mod.rs
@@ -1,0 +1,175 @@
+//! Shared real-runtime R2 Gate setup.
+
+use super::*;
+
+pub(super) struct R2Gate {
+    pub(super) _temp: tempfile::TempDir,
+    pub(super) mock: MockS3,
+    pub(super) storage: Arc<PlatformStorage>,
+    pub(super) objects: R2ObjectStore,
+    pub(super) artifacts: ArtifactStore,
+    pub(super) pins: ResourcePins,
+    pub(super) transport: WorkerdTransport,
+    pub(super) supervisor: Arc<WorkerdSupervisor>,
+    pub(super) shutdown_tx: tokio::sync::watch::Sender<bool>,
+    pub(super) source_task: tokio::task::JoinHandle<Result<(), open_compute_core::PlatformError>>,
+    pub(super) binding_task: tokio::task::JoinHandle<Result<(), open_compute_core::PlatformError>>,
+}
+
+pub(super) async fn start(r2_config: R2Config, s3_endpoint: Option<&str>) -> R2Gate {
+    let workerd = std::env::var_os("OPEN_COMPUTE_TEST_WORKERD")
+        .map(PathBuf::from)
+        .expect("OPEN_COMPUTE_TEST_WORKERD must name the verified stock runtime");
+    let root = repo_root();
+    let lock = root.join("packages/runtime/workerd.lock.json");
+    let assets = root.join("packages/runtime");
+    let temp = tempfile::tempdir().unwrap();
+    let storage = Arc::new(
+        PlatformStorage::bootstrap(&storage_config(&temp.path().join("data")), &SystemClock)
+            .unwrap(),
+    );
+    let mock = MockS3::spawn("open-compute").await;
+    if let Some(endpoint) = s3_endpoint {
+        let url: axum::http::Uri = endpoint.parse().unwrap();
+        assert_eq!(url.scheme_str(), Some("http"));
+        assert!(
+            url.port_u16().is_some(),
+            "qualification fixture needs an explicit port"
+        );
+        assert_eq!(url.path(), "/");
+        assert!(url.query().is_none());
+        assert_eq!(
+            url.host(),
+            Some("127.0.0.1"),
+            "qualification fixture must be loopback-only"
+        );
+    }
+    let (artifacts, objects) = stores(s3_endpoint.unwrap_or(&mock.endpoint));
+    let runtime = verify_runtime_binary(&lock, &workerd, Duration::from_secs(10), &Redactor::new())
+        .await
+        .expect("formal pinned runtime");
+
+    let source_auth = GenerationAuthRegistry::new();
+    let binding_auth = GenerationAuthRegistry::new();
+    let source_listener = bind_runtime_source().await.unwrap();
+    let source_addr = source_listener.local_addr().unwrap();
+    let binding_listener = bind_binding_backend().await.unwrap();
+    let binding_addr = binding_listener.local_addr().unwrap();
+    let pins = ResourcePins::new();
+    let r2_service = Arc::new(
+        R2BindingService::new(
+            storage.clone(),
+            pins.clone(),
+            objects.clone(),
+            r2_config.clone(),
+        )
+        .unwrap(),
+    );
+    let (shutdown_tx, mut source_shutdown) = tokio::sync::watch::channel(false);
+    let mut binding_shutdown = shutdown_tx.subscribe();
+    let source_task = tokio::spawn({
+        let source =
+            RuntimeSource::new(storage.clone(), artifacts.clone(), BundleLimits::default());
+        let auth = source_auth.clone();
+        async move {
+            serve_runtime_source(source_listener, source, auth, async move {
+                let _ = source_shutdown.changed().await;
+            })
+            .await
+        }
+    });
+    let binding_task = tokio::spawn({
+        let binding_storage = storage.clone();
+        let executor_storage = storage.clone();
+        let auth = binding_auth.clone();
+        let pins = pins.clone();
+        let pins_for_d1 = pins.clone();
+        let storage_for_d1 = storage.clone();
+        async move {
+            serve_binding_backend(
+                binding_listener,
+                binding_storage,
+                auth,
+                pins,
+                Arc::new(SqliteKvBindingExecutor::new(
+                    executor_storage,
+                    Arc::new(SystemClock),
+                )),
+                None,
+                Some(r2_service),
+                Some(Arc::new(open_compute_service::D1BindingService::new(
+                    storage_for_d1,
+                    pins_for_d1,
+                    open_compute_core::D1Config::default(),
+                ))),
+                open_compute_core::DurableObjectsConfig::default(),
+                open_compute_core::QueuesConfig::default(),
+                open_compute_core::WorkflowsConfig::default(),
+                None,
+                async move {
+                    let _ = binding_shutdown.changed().await;
+                },
+            )
+            .await
+        }
+    });
+
+    let compiler = StaticConfigCompiler::new(
+        runtime.clone(),
+        lock.clone(),
+        assets,
+        storage.data_dir().runtime_dir(),
+        PlatformReleaseMeta {
+            version: "p0.5-gate".to_owned(),
+        },
+        Duration::from_secs(20),
+        Redactor::new(),
+    )
+    .with_generation_auth(source_auth.clone())
+    .with_binding_generation_auth(binding_auth.clone());
+    let supervisor_slot = Arc::new(Mutex::new(None));
+    let transport = WorkerdTransport::new(source_auth.clone(), supervisor_slot.clone())
+        .with_test_request_body_limit(32 * 1024 * 1024);
+    let do_storage = storage
+        .data_dir()
+        .prepare_durable_object_storage(
+            &storage.identity().platform_id.to_string(),
+            runtime.version_output(),
+        )
+        .unwrap();
+    let supervisor = Arc::new(WorkerdSupervisor::new(
+        WorkerdSupervisorOptions {
+            runtime,
+            compiler,
+            config: runtime_config(),
+            clock: Arc::new(SystemClock),
+            jitter: Arc::new(OsJitter),
+            redactor: Redactor::new(),
+            lease_path: Some(storage.data_dir().runtime_dir().join("p0-5-gate.lease")),
+        },
+        vec![
+            ExternalServiceAddress::loopback("runtime-source", source_addr).unwrap(),
+            ExternalServiceAddress::loopback("binding-backend", binding_addr).unwrap(),
+            ExternalServiceAddress::loopback("observability-backend", binding_addr).unwrap(),
+        ],
+        vec![DirectoryServicePath::local("do-storage", &do_storage).unwrap()],
+        vec![source_auth, binding_auth],
+    ));
+    *supervisor_slot.lock().unwrap() = Some(supervisor.clone());
+    supervisor.start();
+    wait_running(&supervisor, Duration::from_secs(30)).await;
+
+    R2Gate {
+        _temp: temp,
+        mock,
+        storage,
+        objects,
+        artifacts,
+        pins,
+        transport,
+        supervisor,
+        shutdown_tx,
+        source_task,
+        binding_task,
+    }
+}

--- a/crates/service/tests/p0_5_r2_support/uploads.rs
+++ b/crates/service/tests/p0_5_r2_support/uploads.rs
@@ -1,0 +1,335 @@
+//! Large concurrent uploads through real HTTP, stock workerd, R2 and D1.
+
+use super::*;
+use futures::StreamExt as _;
+use http_body_util::BodyExt as _;
+use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use hyper_util::rt::TokioExecutor;
+use open_compute_storage::{R2MultipartRepository, R2MultipartState};
+use open_compute_workers::{
+    CreateResourceOutcome, CreateResourceRequest, D1ResourceDriver, ResourceController,
+};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+
+const TOTAL: usize = 241_910_375;
+const PART: usize = 8 * 1024 * 1024;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_large_upload_keeps_runtime_responsive() {
+    let config = R2Config {
+        max_object_bytes: 256 * 1024 * 1024,
+        max_staging_bytes: 64 * 1024 * 1024,
+        max_concurrent_uploads: 4,
+        ..R2Config::default()
+    };
+    // Explicit local-provider qualification only; the canonical Gate does not pass this env.
+    let endpoint = std::env::var("OPEN_COMPUTE_TEST_R2_S3_ENDPOINT").ok();
+    let gate = support::start(config.clone(), endpoint.as_deref()).await;
+    let account = gate.storage.identity().default_account_id;
+    let bucket = create_bucket(&gate.storage, &gate.objects, &config, account).await;
+    let db = match ResourceController::new(
+        &gate.storage,
+        gate.pins.clone(),
+        D1ResourceDriver::new(
+            &gate.storage,
+            open_compute_core::D1Config::default().database_quota_bytes,
+        ),
+    )
+    .create(&CreateResourceRequest {
+        account_id: account,
+        kind: BindingKind::D1Database,
+        name: "upload-index".to_owned(),
+        idempotency_key: "upload-index".to_owned(),
+        driver_schema_version: open_compute_storage::D1_DATABASE_SCHEMA_VERSION,
+        request_id: RequestId::generate(),
+        now_ms: 20,
+    })
+    .unwrap()
+    {
+        CreateResourceOutcome::Applied(result) => result.resource_id,
+        CreateResourceOutcome::Replay(_) => panic!("unexpected resource replay"),
+    };
+    let (worker, _) = WorkerRepository::new(gate.storage.db())
+        .create_worker(
+            account,
+            "large-upload",
+            RequestId::generate(),
+            21,
+            1_000_000,
+        )
+        .unwrap();
+    let versions = VersionController::new(
+        &gate.storage,
+        gate.artifacts.clone(),
+        Arc::new(gate.transport.clone()),
+        BundleLimits::default(),
+    );
+    let mut input = request(account, worker.id, bucket, "upload-version", SOURCE, 22);
+    input.bindings.insert(
+        "DB".to_owned(),
+        VersionBindingInput {
+            kind: BindingKind::D1Database,
+            id: db,
+            permissions: CanonicalPermissions::default(),
+            config: CanonicalBindingConfig::default(),
+        },
+    );
+    let version = deploy(&versions, input, &gate.supervisor).await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let transport = gate.transport.clone();
+    let router = axum::Router::new().fallback(move |request: axum::extract::Request| {
+        let transport = transport.clone();
+        let version = version.clone();
+        async move {
+            transport
+                .dispatch(
+                    DispatchTarget {
+                        account_id: account,
+                        worker_id: worker.id,
+                        version_id: version.id,
+                        worker_code_sha256: hex::encode(version.worker_code_sha256),
+                        entrypoint: None,
+                        route_generation: 1,
+                        request_id: RequestId::generate(),
+                    },
+                    request,
+                )
+                .await
+                .unwrap()
+        }
+    });
+    let (stop, stopped) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = stopped.await;
+            })
+            .await
+            .unwrap();
+    });
+    let client = Client::builder(TokioExecutor::new()).build_http::<Body>();
+    let created =
+        checked_json(send(&client, "POST", format!("{base}/create"), Body::empty()).await).await;
+    let upload_id = created["uploadId"].as_str().unwrap().to_owned();
+    let repo = R2MultipartRepository::new(gate.storage.db());
+    let started = Instant::now();
+    let uploads = futures::stream::iter(0..TOTAL.div_ceil(PART))
+        .map(|index| {
+            let client = client.clone();
+            let url = format!("{base}/part?uploadId={upload_id}&number={}", index + 1);
+            async move {
+                let bytes = tokio::task::spawn_blocking(move || part_bytes(index))
+                    .await
+                    .unwrap();
+                let started = Instant::now();
+                let part = checked_json(send(&client, "PUT", url, Body::from(bytes)).await).await;
+                (part, started.elapsed())
+            }
+        })
+        .buffer_unordered(4)
+        .collect::<Vec<_>>();
+    tokio::pin!(uploads);
+    let mut probes = 0;
+    let mut max_probe = Duration::ZERO;
+    let results = loop {
+        tokio::select! {
+            result = &mut uploads => break result,
+            () = tokio::time::sleep(Duration::from_millis(50)) => {
+                let probe_started = Instant::now();
+                let response = send(&client, "GET", format!("{base}/ping"), Body::empty()).await;
+                assert_eq!(response.status(), 200);
+                assert_eq!(response.into_body().collect().await.unwrap().to_bytes(), "pong");
+                max_probe = max_probe.max(probe_started.elapsed());
+                assert!(max_probe < Duration::from_secs(2), "lightweight request stalled: {max_probe:?}");
+                probes += 1;
+            }
+        }
+    };
+    let upload_elapsed = started.elapsed();
+    assert!(probes > 0, "no concurrent responsiveness probe executed");
+    let max_part = results.iter().map(|(_, elapsed)| *elapsed).max().unwrap();
+    let mut parts: Vec<_> = results.into_iter().map(|(part, _)| part).collect();
+    parts.sort_by_key(|part| part["partNumber"].as_i64().unwrap());
+    let persisted = repo.list_parts(&upload_id).unwrap();
+    assert_eq!(persisted.len(), TOTAL.div_ceil(PART));
+    for (stored, returned) in persisted.iter().zip(&parts) {
+        assert_eq!(stored.part_number, returned["partNumber"]);
+        assert_eq!(stored.etag, returned["etag"]);
+    }
+    assert_eq!(
+        persisted.iter().map(|part| part.size).sum::<u64>(),
+        TOTAL as u64
+    );
+    assert_eq!(
+        repo.get(account, bucket, &upload_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        R2MultipartState::Open
+    );
+    let before = send(&client, "GET", format!("{base}/get"), Body::empty()).await;
+    assert_eq!(
+        before.status(),
+        404,
+        "incomplete object must not be visible"
+    );
+    let indexed =
+        checked_json(send(&client, "GET", format!("{base}/state"), Body::empty()).await).await;
+    assert_eq!(indexed["count"], parts.len());
+    assert_eq!(indexed["bytes"], TOTAL);
+    let completed = checked_json(
+        send(
+            &client,
+            "POST",
+            format!("{base}/complete?uploadId={upload_id}"),
+            Body::from(serde_json::to_vec(&parts).unwrap()),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(completed["size"], TOTAL);
+    assert_eq!(
+        repo.get(account, bucket, &upload_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        R2MultipartState::Completed
+    );
+    let response = send(&client, "GET", format!("{base}/get"), Body::empty()).await;
+    assert_eq!(response.status(), 200);
+    let mut stream = response.into_body().into_data_stream();
+    let mut actual = Sha256::new();
+    let mut length = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.unwrap();
+        length += chunk.len();
+        actual.update(&chunk);
+    }
+    let expected = tokio::task::spawn_blocking(|| {
+        let mut digest = Sha256::new();
+        for index in 0..TOTAL.div_ceil(PART) {
+            digest.update(part_bytes(index));
+        }
+        digest.finalize()
+    })
+    .await
+    .unwrap();
+    assert_eq!(length, TOTAL);
+    assert_eq!(
+        actual.finalize(),
+        expected,
+        "readback must match every uploaded byte"
+    );
+    assert!(
+        std::fs::read_dir(gate.storage.data_dir().root().join("r2-staging"))
+            .unwrap()
+            .next()
+            .is_none()
+    );
+    assert_eq!(gate.pins.count(bucket), 0);
+    let provider_parts = gate
+        .mock
+        .recorded()
+        .into_iter()
+        .filter(|request| request.method == "PUT" && request.query.contains("partNumber="))
+        .count();
+    if endpoint.is_none() {
+        assert_eq!(provider_parts, parts.len(), "unexpected provider retries");
+    }
+    println!(
+        "large upload profile={} bytes={TOTAL} concurrency=4 upload_ms={} max_part_ms={} probes={probes} max_probe_ms={} sha256={}",
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        },
+        upload_elapsed.as_millis(),
+        max_part.as_millis(),
+        max_probe.as_millis(),
+        hex::encode(expected)
+    );
+    let _ = stop.send(());
+    server.await.unwrap();
+    gate.supervisor.shutdown().await;
+    assert_eq!(gate.supervisor.owner_registry_len(), 0);
+    let _ = gate.shutdown_tx.send(true);
+    gate.source_task.await.unwrap().unwrap();
+    gate.binding_task.await.unwrap().unwrap();
+}
+
+fn part_bytes(index: usize) -> Vec<u8> {
+    let length = (TOTAL - index * PART).min(PART);
+    (0..length)
+        .map(|offset| ((offset % 251 + index * 17) % 256) as u8)
+        .collect()
+}
+
+async fn send(
+    client: &Client<HttpConnector, Body>,
+    method: &str,
+    url: String,
+    body: Body,
+) -> axum::http::Response<hyper::body::Incoming> {
+    tokio::time::timeout(
+        Duration::from_secs(35),
+        client.request(
+            Request::builder()
+                .method(method)
+                .uri(url)
+                .body(body)
+                .unwrap(),
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+}
+
+async fn checked_json(response: axum::http::Response<hyper::body::Incoming>) -> Value {
+    let status = response.status();
+    let text = String::from_utf8(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert_eq!(status, 200, "{text}");
+    serde_json::from_str(&text).unwrap()
+}
+
+const SOURCE: &str = r#"export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/ping") return new Response("pong");
+    if (url.pathname === "/create") {
+      await env.DB.exec("CREATE TABLE parts (part INTEGER PRIMARY KEY, size INTEGER NOT NULL)");
+      return Response.json(await env.BUCKET.createMultipartUpload("large.bin"));
+    }
+    if (url.pathname === "/part") {
+      const bytes = await request.arrayBuffer();
+      const number = Number(url.searchParams.get("number"));
+      const upload = env.BUCKET.resumeMultipartUpload("large.bin", url.searchParams.get("uploadId"));
+      const part = await upload.uploadPart(number, bytes);
+      await env.DB.prepare("INSERT INTO parts VALUES (?, ?)").bind(number, bytes.byteLength).run();
+      return Response.json(part);
+    }
+    if (url.pathname === "/state") {
+      return Response.json(await env.DB.prepare("SELECT COUNT(*) AS count, SUM(size) AS bytes FROM parts").first());
+    }
+    if (url.pathname === "/complete") {
+      const upload = env.BUCKET.resumeMultipartUpload("large.bin", url.searchParams.get("uploadId"));
+      return Response.json(await upload.complete(await request.json()));
+    }
+    if (url.pathname === "/get") {
+      const object = await env.BUCKET.get("large.bin");
+      return object ? new Response(object.body) : new Response("missing", { status: 404 });
+    }
+    return new Response("missing", { status: 404 });
+  }
+};"#;

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -5,7 +5,8 @@
 ## 固定输入与范围
 
 - 从 `main` 的 `62cb7a0c92059b9cc7a4c956915094d671d075b1` 创建 `codex/release-0.1.0`。
-  当前独立 R2 修复分支不在本次发布准备变更内；最终源码以合入 main 后的 annotated tag 为准。
+  最初未包含独立 R2 修复；2026-09-05 用户追加要求，将 issue #4 的本地提交
+  `970650a17bd1906f699921ef7c5b8d88c6f1bed8` 一起合入后再发布。最终源码以合入 main 后的 annotated tag 为准。
 - Cargo workspace 与 lockfile 已是 `0.1.0`，不制造无意义的版本或 lockfile 变动。
 - workerd 保持 `v1.20260830.1`，revision `e9dda5963aba7ee4323960db795690ec78fec118`，
   compatibility date `2026-08-30`；四平台摘要以正式 `packages/runtime/workerd.lock.json` 为准。
@@ -15,7 +16,9 @@
   并上传每个平台的 Gate 证据。
 - release 先完成静态检查与 90% coverage，再运行 Linux/macOS 各一轮完整 Gate；每个 job 显式构建
   runtime assets。四平台产物经只读聚合，再由 release environment 中唯一写权限 job 发布。
-- tag 必须对应已经通过 main push CI 的精确 commit；不修改已推送 tag，不覆盖既有 assets。
+- tag 必须对应已经通过 main push CI 的精确 commit，不覆盖既有 assets。用户明确授权本次
+  尚未公开发布的 `v0.1.0` 在修复验收后重建；随后又追加纳入 issue #4，故最终 tag 必须包含 R2 修复。
+  旧 tag object 与首次失败记录保留；不把这一例外扩展到已公开 Release。
 
 ## 发布内容与限制
 
@@ -75,3 +78,28 @@ PR CI `33951624671` 的产品 Gates 通过，但 `p3-contract` 的 source baseli
 - [ ] 正式 latest Release、逐目标文件大小/SHA-256、发布完成时间。
 
 未完成上述验证前保留本文于 acceptance；完成后将实际结果归档到 implemented 并更新索引。
+
+## Issue #4 纳入首次发行
+
+本地 R2 修复的原始实现、Adobe S3Mock debug/release 对比、90.044691% coverage 和 1,140-case
+最终 Gate 记录保持原样，见 [issue #4 完成记录](../implemented/github-issue-4-r2-upload.md)。
+本次集成基于已合入的进程夹具修复；只重新计算合并输入的 conformance source digest，未更改 R2
+生产实现。合并后的完整 CI、coverage、最终 Gate 和四平台 package 仍须以新源码实际执行，不能复用
+旧提交的通过状态作为新版本的发行资格。此前不包含 R2 的 tag 暂不重建，不发布部分源码。
+
+集成后的 macOS arm64 插桩 development Gate `p0-5` 两个注册用例通过，69.21 s；
+报告为 `.temp/gate-run/20260905T184154-f82ad9af/report.json`。同尺寸上传的分片阶段为 11,193 ms，
+最慢分片 517 ms；171 次轻量请求探测中最慢 141 ms，读回 SHA-256 与原记录一致。
+这是带 coverage 插桩的 debug 观察，不与原记录的非插桩 debug/release 时间混为同一性能基线。
+
+集成复核未发现新的 R2 兼容性问题：原始 R2 生产文件和回归与 `970650a17` 字节一致，
+公开类型及 formal workerd pin 未变；完整发行验收仍等待合入后的最终源码。
+
+| 集成检查面 | 结论 | 证据 |
+| --- | --- | --- |
+| multipart 返回值、ETag、SSE-C | aligned | pinned upstream declarations/source、合并后的真实 stock-workerd R2 Gate |
+| PUT checksum、取消及资源持有 | aligned | 原始成功/失败/取消回归和已保留的完整验收；有界 blocking task 的资源所有权复核 |
+| HTTP metadata 缺省和显式字段 | aligned | 原始 presence-mask 全组合及 Adobe 回读证据；官方 R2 metadata 合同 |
+| 托管 Cloudflare differential | unverified | 本次没有执行新的外部部署，不扩大已有资格声明 |
+
+全球复制/placement 仍是 `OC-R2-001` 的 excluded self-host scope，不构成本次新增差异。

--- a/docs/implemented/README.md
+++ b/docs/implemented/README.md
@@ -12,6 +12,10 @@
 2026-09-05 的 [GitHub Issues #1–#3 修复](github-issues-1-3.md)记录请求体限额、Assets bulk multipart
 与 Cron generation 的独立修复、1,131 用例最终单轮验收及 90.014165% Rust 行覆盖率；未新增远端差分资格。
 
+2026-09-05 的 [GitHub Issue #4：R2 上传优化](github-issue-4-r2-upload.md)记录冗余分片摘要删除、
+有界 PUT checksum 调度、provider 默认 HTTP metadata 修复、231 MiB debug/release 对比，
+以及 1,140 用例最终单轮验收和 90.044691% Rust 行覆盖率；旧开发对象不做兼容迁移。
+
 | 阶段 | 设计 | 完成依据与限制 |
 | --- | --- | --- |
 | G0 | [workerd 可行性验证](g0-workerd-runtime-validation.md) | [结果](g0-results.md)：Conditional Go，精确 `D-abort` 限制仍保留；一次性探测已完成 |

--- a/docs/implemented/github-issue-4-r2-upload.md
+++ b/docs/implemented/github-issue-4-r2-upload.md
@@ -1,0 +1,105 @@
+# GitHub Issue #4：R2 上传调度与大文件验收
+
+状态：Completed，2026-09-05。范围为 [issue #4](https://github.com/elliothux/open-compute/issues/4)
+的上传优化、同尺寸并发回归、debug/release 对比和本地验收；没有修改 LynxOS 或 Cloudflare 账号上的服务。
+
+## 修复
+
+1. `UploadPart` 改用只有路径和精确长度的 `R2PartSource`，删除异步处理线程内那次不被下游消费的
+   MD5、SHA-1、SHA-256、SHA-384、SHA-512 全文件计算，以及无消费的 part source version。
+   S3 adapter 的 `Content-MD5` 和 Local backend 的内容完整性处理不变。
+2. 普通 Worker/管理面 PUT 的必需摘要计算进入有界 blocking task。任务持有 staging 文件、字节配额
+   和 CPU permit，取消等待不会提前释放仍被计算占用的资源。staging concern 从已有过长的
+   `r2_backend.rs` 提取到 `r2_backend_staging.rs`，没有新增队列、后台上传成功语义或兼容分支。
+3. Adobe S3Mock 对比暴露了同一路径的第二处故障：29 个分片及最终对象已经保存，但 provider 自动补入的
+   `Content-Type: application/octet-stream` 与未指定的 HTTP metadata 不同，Complete 因此返回
+   `R2_OBJECT_METADATA_INVALID`。当前 Day1 对象使用必需的 `oc-r2-http-fields` presence mask 区分
+   用户声明字段与 provider 默认字段；显式字段丢失、标记缺失或损坏仍 fail closed。
+4. SigV4 fixture 的 multipart complete 也删除了只取 SHA-256 却计算五种摘要的无用工作；保留实际使用的
+   SHA-256、part MD5 和 multipart ETag 计算，没有弱化完整性断言。
+
+未修改 `runtime_bridge` 的 30 秒 response-header deadline，也未改变 multipart 的持久状态机、
+part/complete ETag、SSE-C、配额或 complete 后才发布对象的顺序。
+
+## 并发上传证据
+
+同一维护用例 `p0-5::uploads::concurrent_large_upload_keeps_runtime_responsive` 通过真实 HTTP、
+stock workerd、R2 与 SQLite/D1 执行：合成输入 241,910,375 bytes，8 MiB 分片，共 29 片，4 并发。
+Worker 先等待 `uploadPart()`，再写 D1；测试核对 part number/ETag/size authority、D1 总数与总字节数、
+Complete 前对象不可见、Complete 后状态和流式读回 SHA-256。
+
+| 本次单次运行 | provider | 分片上传阶段 | 最慢分片 | 轻量请求探测数 | 最慢轻量请求 |
+| --- | --- | ---: | ---: | ---: | ---: |
+| debug | Adobe S3Mock | 3,286 ms | 531 ms | 46 | 120 ms |
+| release | Adobe S3Mock | 2,378 ms | 478 ms | 34 | 66 ms |
+| 最终非插桩 Gate / debug | 仓库 SigV4 fixture | 4,447 ms | 688 ms | 69 | 89 ms |
+
+Adobe 镜像固定为
+`adobe/s3mock@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2`，
+与 issue 指定镜像一致；分别使用本次独立创建的 loopback-only 容器，没有下载镜像。
+表中时间是分片阶段，不包含准备、Complete、读回或测试清理；是单次观察，不是吞吐 SLA 或重复压测中位数。
+所有运行的读回摘要相同：
+`7fa67c90cb2e12b9700ae89db64ae62fe35879932c28b08bc05ab027fc41c1c3`。
+
+取消/超时回归另证明：未结束的分片 stream 被取消或超时后，staging 字节数归零、文件与 pin 清理、
+不产生 part/object authority，上传许可可再次获取，显式 abort 进入终态。受控 blocking-pool 屏障证明
+PUT checksum 等待被取消时文件、字节配额和 CPU permit 保留到计算结束；摘要失败也释放这些资源。
+
+原始 cached debug binary 的源码身份没有独立验证，本次不能反推出旧超时只有一个原因，也没有重新运行
+原始 LynxOS UI 或用户文件。证据证明的是当前生产处理链路、同尺寸输入及同版本 provider 的场景。
+
+## 构建、静态检查与最终验收
+
+基线 commit 为 `62cb7a0c92059b9cc7a4c956915094d671d075b1`，包含本次修改的冻结工作树：
+
+- Gate source SHA-256：`bfbabb39134e038abd099752225fb1c37dcc77390811293ed840de294e60caa7`；
+- conformance source digest：`5746485ff24af5503b10ab4fb63b293d2bd5c3829e1adde683140111c89c704f`，
+  该算法额外排除 `test/conformance/baseline.json`；
+- stock workerd：`v1.20260830.1`，revision `e9dda5963aba7ee4323960db795690ec78fec118`，
+  effective date `2026-08-30`；使用已存在并经构建/运行时验证的 `.temp/workerd-pin/` archive 和 binary。
+
+`bun run build`、`bun run check:generated`、`cargo fmt --all --check`、canonical workspace/all-targets/
+all-features Clippy（`--keep-going -- -D warnings`）、无默认特性检查（`RUSTFLAGS='-D warnings'`）、
+Rust 1.98.0 all-targets 检查、Cargo metadata 和 dependency-boundary 检查均通过。
+没有修改 JS/TS 实现；未重复执行与本次修改无关的 JS suite。
+
+- `./test/coverage.sh` 一次：49 targets、1,140/1,140 cases，914.70 s；按仓库既有排除规则，
+  Rust 行覆盖率为 **90.044691%（109,606 / 121,724）**。未修改覆盖率规则或降低门槛。
+- 冻结源码后的 `./test/gate.py --workspace` 一次：49 targets、1,140/1,140 cases，799.13 s；
+  native inventory 已核对，无 ignored cases。没有第二次相同输入的最终 aggregate。
+
+原始证据保留于仓库忽略目录：
+
+- `.temp/issue4/adobe-debug-fixed.log`、`.temp/issue4/adobe-release.log`；
+- `.temp/issue4/failed/adobe-debug-metadata.log` 与 `adobe-completed-object-headers.txt`；
+- `.temp/issue4/` 下的 static、provider、coverage 和 final Gate 日志；
+- `.temp/gate-run/20260905T134640-40d71b53/report.json`（coverage）；
+- `.temp/gate-run/20260905T140249-6b780bc2/report.json`（最终 Gate）。
+
+## cf-compatibility-check 复核
+
+本次按 `cf-compatibility-check` 检查工作树；默认分支 merge-base 等于上述 HEAD，没有额外的 committed
+branch diff。合同采用已归档的 runtime compatibility design、当前兼容矩阵和 deviation registry；
+stable types 固定为 `@cloudflare/workers-types@5.20260830.1`，没有手写或修改 Cloudflare 类型。
+
+| 改动面 | 结论 | 依据 |
+| --- | --- | --- |
+| `uploadPart` 返回值、part/complete ETag、SSE-C | aligned | pinned `R2MultipartUpload`/`R2UploadedPart`、typed-store 与 stock-workerd R2 Gate；只删除无消费的私有输入 |
+| PUT checksum 与完成后可见性 | aligned | 原算法和 mismatch 拒绝保留；有界 blocking 调度、取消/失败回归及最终 Gate |
+| HTTP metadata 缺省与显式字段 | aligned | presence-mask 全组合、缺失/损坏拒绝、Adobe 无 metadata multipart 与现有显式字段 round-trip |
+| Cloudflare 托管端 differential | unverified | 本次没有部署 Cloudflare；不能把本地通过外推为新的托管端差分资格 |
+
+当前 [Cloudflare R2 Worker API](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/)
+定义的 multipart/metadata/checksum surface 保持不变；
+[Tokio blocking-task 生命周期](https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html)
+要求不能把取消等待等同于任务停止。审查范围内没有剩余可操作的不兼容 finding；全球复制/placement
+属于既有 `OC-R2-001` excluded self-host scope，没有新增 deviation。整个平台的独立托管资格仍按既有
+acceptance 文档管理，不因本报告变成全平台 Cloudflare Go。
+
+## Day1 与操作边界
+
+缺少新 HTTP metadata 标记的旧开发 R2 对象/上传不会被迁移或兼容读取。没有重置已有开发数据、
+修改父项目、清理用户 Rust cache 或改动现有 Cloudflare 服务。
+两个专用 S3Mock 容器及其可再生成的合成数据已精确清理，并确认本次 label 下无残留容器；
+日志和失败证据保留。client disconnect 仍不被承诺为 stock-workerd 的可靠取消信号，后端未知提交
+结果继续使用既有持久 intent/reconcile 合同。

--- a/docs/references/cloudflare-compatibility.md
+++ b/docs/references/cloudflare-compatibility.md
@@ -73,6 +73,22 @@ backend 和 workerd 内部 listener 仍仅监听 loopback。
 
 ## 关键实现说明
 
+### R2 上传调度与完整性
+
+`uploadPart` 的 staging source 只携带路径和精确长度，不计算不被后端消费的五种完整对象摘要。
+S3 adapter 仍计算并发送 `Content-MD5`，Local backend 仍执行自己的内容完整性校验；part ETag、
+complete ETag、SSE-C、分片大小校验和 SQLite multipart authority 不变。
+当前 Day1 对象 metadata 使用必需的 `oc-r2-http-fields` 六位 presence mask 记录 tenant 显式设置的
+HTTP 字段；S3 provider 自行补入的默认 header 不成为 R2 用户 metadata。显式字段在后端丢失仍拒绝，
+缺少/损坏该标记也拒绝，不对旧开发对象 backfill。这避免无 `httpMetadata` 的 multipart 在 Adobe S3Mock
+自动返回 `Content-Type: application/octet-stream` 时被误判为 complete 元数据损坏。
+普通 Worker/管理面 PUT 所需的 MD5、SHA-1/256/384/512 计算移入有界 blocking task，CPU 并发上限沿用
+`r2.max_concurrent_uploads`。任务持有临时文件、staging 字节配额及 CPU permit，直到计算真正结束；
+取消等待不把尚在执行的哈希误当成已经清理。body staging 继续流式写入并受总字节预算约束。
+成功响应仍等待后端保存及元数据提交，未改成后台接受任务；30 秒 runtime response-header deadline 未延长。
+这些实现调整不改变 [Cloudflare R2 Worker API](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/)
+的 PUT checksum、multipart 返回字段及 complete 后可见性合同，也不新增 topology deviation。
+
 ### 租户请求体预算
 
 控制面已注册路由的 4 KiB（v4 为 64 MiB）声明长度检查不作用于 tenant ingress fallback，

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -85,6 +85,17 @@ Workflow；open-compute 只通过 `CLOUDFLARE_API_BASE_URL` 选择本地 v4 orig
 
 ## 单轮覆盖原则
 
+P0.5 的 `uploads::concurrent_large_upload_keeps_runtime_responsive` 使用真实 HTTP、stock workerd、
+SQLite/D1 和 SigV4 S3 fixture，上传 241,910,375 bytes（8 MiB 分片、4 并发），核对分片 authority、
+D1 记录、complete 前不可见、流式读回 SHA-256 和并发轻量请求延迟。它属于普通 Gate 的固定回归，
+不是吞吐 SLA 或重复压测。单元测试另覆盖 staging 取消/超时和 blocking checksum 的资源生命周期。
+
+需要与特定本机 S3 provider 对比时，可对同一 case 显式设置 `OPEN_COMPUTE_TEST_R2_S3_ENDPOINT`，
+仅接受 `http://127.0.0.1:<port>`。调用方必须先创建专用、可删除的 fixture 和 `open-compute` bucket；
+不可指向现有服务或业务 bucket。该环境变量不在普通 Gate 的传递白名单内，正常验收始终使用自有
+SigV4 fixture。分别用 Cargo debug/release 构建并执行一次该 exact case，记录 profile、provider pin、
+源码身份及实际输出；provider 初始化/清理属于这次独立 qualification，不增加普通 Gate 的 Docker 依赖。
+
 唯一 case inventory 是 [`test/gate_cases.py`](../../test/gate_cases.py)，按完整 Rust 测试名登记。
 调度器将 `--list` 的实际用例集合与该表逐项比对：新增、删除、改名、重复登记、空 Gate 或非预期
 discovery 都在业务用例启动前失败。每个选定 case 用 `--exact` 执行一次，并在所属宿主内串行运行。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "e4e4c44bad4d782561b614f270f84cb06dae9d81b3623618e55cf5010e90e106",
+  "openComputeRevision": "0a7fcf39a78a34496ba402c18f3ee6875622278a7c38dfd1b47389583b14f6eb",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {

--- a/test/gate_cases.py
+++ b/test/gate_cases.py
@@ -90,7 +90,10 @@ TIMING = {
     'p0-2': ('p0_2_real_worker_create_validate_dispatch_promote_rollback_restart',),
     'p0-3': ('p0_3_real_binding_matrix',),
     'p0-4': ('p0_4_real_kv_matrix',),
-    'p0-5': ('p0_5_real_r2_facade_matrix',),
+    'p0-5': (
+        'p0_5_real_r2_facade_matrix',
+        'uploads::concurrent_large_upload_keeps_runtime_responsive',
+    ),
     'p0-6': ('p0_6_real_d1_facade_and_backend_matrix',),
     'p0-7': ('p0_7_real_durable_objects_matrix',),
     'p0-8': ('p0_8_real_scheduler_alarm_matrix',),


### PR DESCRIPTION
## Problem and change

Closes #4.

Merge the existing local R2 upload fix into the 0.1.0 release source. Concurrent 8 MiB multipart uploads previously performed unused five-algorithm hashing on async workers; required PUT hashing now runs in a bounded blocking task that retains its staging file, byte quota, and CPU permit until completion. Multipart upload keeps the backend transfer checksums and original 30-second response deadline.

A required Day1 HTTP-metadata presence mask prevents S3 provider defaults from becoming tenant metadata or causing multipart completion to reject an otherwise valid upload. Missing declared fields and corrupt/missing markers fail closed; existing development data is not migrated or reset.

The original local commit is 970650a17bd1906f699921ef7c5b8d88c6f1bed8. All its Rust changes and regression cases are unchanged. The only cherry-pick conflict was the conformance source digest, recomputed from the combined source. Release documentation now includes issue #4 in scope and retains the original qualification record.

## Validation

- Original fix evidence: 1,140/1,140 workspace cases; 90.044691% Rust line coverage; debug/release comparisons against the pinned Adobe S3Mock image. These are historical inputs, not new release qualification.
- Integrated macOS arm64 instrumented p0-5 Gate: both registered cases passed, including 241,910,375 bytes at 8 MiB x 4 concurrency, matching readback SHA-256, visibility/state checks, and runtime responsiveness. Maximum lightweight latency: 141 ms across 171 probes. Report: .temp/gate-run/20260905T184154-f82ad9af/report.json.
- Runtime build, formatting, conformance source identity, and diff hygiene passed locally. Full combined-source static checks and workspace acceptance run in hosted CI; release coverage and four native package qualifications follow the final merged source.
- Compatibility review found no new mismatch in the changed R2 scope. Hosted differential was not rerun. The earlier process restart fixture fix remains included, and full macOS document parsing remains enabled.
