### PR TITLE
fix(runtime): handle exited children during release verification

### DIFF
--- a/crates/runtime/src/process.rs
+++ b/crates/runtime/src/process.rs
@@ -1280,7 +1280,10 @@ static STDOUT_FLUSH_FAIL: AtomicBool = AtomicBool::new(false);
 static STDOUT_SYNC_FAIL: AtomicBool = AtomicBool::new(false);
 
 #[cfg(test)]
-static PGID_VERIFY_HOOK: Mutex<Option<Arc<dyn Fn(i32) -> bool + Send + Sync>>> = Mutex::new(None);
+type PgidVerifyHook = Arc<dyn Fn(i32) -> bool + Send + Sync>;
+
+#[cfg(test)]
+static PGID_VERIFY_HOOK: Mutex<Option<PgidVerifyHook>> = Mutex::new(None);
 
 #[cfg(any(test, feature = "test-support"))]
 static REAP_PROBE_FAIL: AtomicBool = AtomicBool::new(false);

--- a/crates/runtime/src/process.rs
+++ b/crates/runtime/src/process.rs
@@ -493,11 +493,13 @@ async fn run_image(
     let pid = child.id() as i32;
     let mut owned = OwnedChild::new(child, pid);
     // `--version` can exit before getpgid. spawn already used process_group(0).
-    // Skip only the *read* failure when the pid is already gone; leader mismatch still fails.
+    // An exited, unreaped child can still pass kill(pid, 0). Use its owned wait status.
     match verify_self_pgid(pid) {
         Ok(()) => {}
         Err(err) => {
-            if err.message() != "failed to read runtime process group" || !pid_already_gone(pid) {
+            if err.message() != "failed to read runtime process group"
+                || owned.try_wait()?.is_none()
+            {
                 return Err(err);
             }
         }
@@ -565,7 +567,7 @@ async fn run_image(
 }
 
 pub(crate) fn verify_self_pgid(pid: i32) -> Result<(), PlatformError> {
-    if pgid_verify_should_fail() {
+    if pgid_verify_should_fail(pid) {
         return Err(PlatformError::new(
             ErrorCode::RuntimeInvalid,
             "failed to read runtime process group",
@@ -1212,13 +1214,6 @@ pub fn set_reap_probe_fail(fail: bool) {
     REAP_PROBE_FAIL.store(fail, Ordering::SeqCst);
 }
 
-fn pid_already_gone(pid: i32) -> bool {
-    let Some(raw) = Pid::from_raw(pid) else {
-        return true;
-    };
-    matches!(test_kill_process(raw), Err(err) if err == rustix::io::Errno::SRCH)
-}
-
 /// Wait until `pid` is gone or `deadline` elapses.
 pub fn wait_pid_gone(pid: i32, deadline: Duration) -> Result<(), PlatformError> {
     let started = std::time::Instant::now();
@@ -1285,7 +1280,7 @@ static STDOUT_FLUSH_FAIL: AtomicBool = AtomicBool::new(false);
 static STDOUT_SYNC_FAIL: AtomicBool = AtomicBool::new(false);
 
 #[cfg(test)]
-static PGID_VERIFY_HOOK: Mutex<Option<Arc<dyn Fn() -> bool + Send + Sync>>> = Mutex::new(None);
+static PGID_VERIFY_HOOK: Mutex<Option<Arc<dyn Fn(i32) -> bool + Send + Sync>>> = Mutex::new(None);
 
 #[cfg(any(test, feature = "test-support"))]
 static REAP_PROBE_FAIL: AtomicBool = AtomicBool::new(false);
@@ -1400,7 +1395,7 @@ fn stdout_sync_should_fail() -> bool {
     false
 }
 
-fn pgid_verify_should_fail() -> bool {
+fn pgid_verify_should_fail(_pid: i32) -> bool {
     #[cfg(test)]
     {
         if let Some(hook) = PGID_VERIFY_HOOK
@@ -1408,7 +1403,7 @@ fn pgid_verify_should_fail() -> bool {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
         {
-            return hook();
+            return hook(_pid);
         }
         false
     }
@@ -1476,7 +1471,7 @@ pub(crate) fn set_stdout_write_fail(fail: bool) {
 }
 
 #[cfg(test)]
-pub(crate) fn set_pgid_verify_fail_hook(hook: impl Fn() -> bool + Send + Sync + 'static) {
+pub(crate) fn set_pgid_verify_fail_hook(hook: impl Fn(i32) -> bool + Send + Sync + 'static) {
     *PGID_VERIFY_HOOK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(hook));

--- a/crates/runtime/src/process_tests.rs
+++ b/crates/runtime/src/process_tests.rs
@@ -177,3 +177,41 @@ fn owner_wait_hard_deadline_reaps_without_waiting_for_the_soft_deadline() {
     assert!(output.timed_out);
     wait_reaped(pid, Duration::from_secs(2)).unwrap();
 }
+
+#[tokio::test]
+async fn exited_unreaped_child_keeps_status_and_output_when_pgid_read_fails() {
+    set_pgid_verify_fail_hook(|pid| {
+        let raw = Pid::from_raw(pid).unwrap();
+        // Wait for this child to exit without reaping it; kill(pid, 0) still succeeds.
+        rustix::process::waitid(
+            rustix::process::WaitId::Pid(raw),
+            rustix::process::WaitIdOptions::EXITED | rustix::process::WaitIdOptions::NOWAIT,
+        )
+        .unwrap();
+        assert!(test_kill_process(raw).is_ok());
+        #[cfg(target_os = "macos")]
+        assert_eq!(getpgid(Some(raw)), Err(rustix::io::Errno::SRCH));
+        true
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let executable = dir.path().join("completed-child");
+    fs::write(&executable, b"#!/bin/sh\nprintf 'completed\\n'\nexit 0\n").unwrap();
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+    let file = File::open(&executable).unwrap();
+    let result = run_verified_fd(
+        &file,
+        &[],
+        Duration::from_secs(2),
+        1024,
+        &Redactor::new(),
+        None,
+    )
+    .await;
+    clear_pgid_verify_fail_hook();
+    let output = result.unwrap();
+    assert!(output.status.unwrap().success(), "{output:?}");
+    assert_eq!(output.stdout, b"completed\n");
+    assert!(output.stderr.is_empty());
+    assert!(!output.timed_out);
+    wait_reaped(output.pid.unwrap(), Duration::from_secs(2)).unwrap();
+}

--- a/crates/runtime/src/tests.rs
+++ b/crates/runtime/src/tests.rs
@@ -2779,7 +2779,7 @@ wait
     set_pgid_verify_fail_hook({
         let pid_file = pid_file.clone();
         let child_file = child_file.clone();
-        move || {
+        move |_| {
             let started = std::time::Instant::now();
             while started.elapsed() < Duration::from_secs(2) {
                 if pid_file.exists() && child_file.exists() {

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -103,3 +103,30 @@ PR CI `33951624671` 的产品 Gates 通过，但 `p3-contract` 的 source baseli
 | 托管 Cloudflare differential | unverified | 本次没有执行新的外部部署，不扩大已有资格声明 |
 
 全球复制/placement 仍是 `OC-R2-001` 的 excluded self-host scope，不构成本次新增差异。
+
+## 第二次发行验证与短命子进程修复
+
+[Issue #4 集成 PR #7](https://github.com/elliothux/open-compute/pull/7) 已合入
+`5ed57bd9ec041cbdddb1aaa331b34fb7237c3fcb`，issue 已关闭。
+[PR CI](https://github.com/elliothux/open-compute/actions/runs/33962041707) 与
+[精确 main CI](https://github.com/elliothux/open-compute/actions/runs/33963262157) 通过；PR 的 Linux 单轮
+workspace 为 49 个测试进程、1,134/1,134 用例，1,085.58 s。macOS 与 Linux 的 cfg 用例数不同，
+不将 Linux 数量写成 macOS 的通过数量。
+
+获授权后重建的 annotated tag object 为 `381a015583d5ed11085133b0de2b29ba0625f248`。
+[第二次发行运行](https://github.com/elliothux/open-compute/actions/runs/33964367514) 的身份、MSRV 和
+Linux/macOS 静态检查通过；coverage 的 R2、P2 exit Gate 通过，但 `p3-services-events` 在
+`workerd --version` 验证阶段返回 `failed to read runtime process group`。coverage 未完成，最终 Gate、
+打包及公开发布均未执行。保留原始 tag object 与失败 artifact，报告为
+`.temp/gate-run/failed/20260905T115923-d2a36573/report.json`。
+
+短命子进程可以已经退出但尚未回收，此时 macOS `getpgid` 返回 ESRCH，而 `kill(pid, 0)` 仍成功。
+旧判断错误地把这种状态当作活进程校验失败。修复只在进程组读取失败时检查所拥有 `Child` 的真实
+退出状态；活进程、进程组 leader 不匹配及 wait 失败继续 fail closed，版本退出码和输出继续校验。
+删除旧的 PID 存在性辅助函数，不引入重试或跳过版本验证。
+
+确定性回归通过 `waitid(EXITED | NOWAIT)` 保留已退出子进程，并在 macOS 断言上述两个系统调用的
+结果；修复前同类回归失败，修复后成功并保留 stdout、成功退出码和回收保证。其余 89 个 runtime
+单元用例通过，日志保留在 `.temp/release-exit-fix/`。修复后的真实 stock-workerd 插桩
+`p3-services-events` 单轮通过，6.77 s；报告为
+`.temp/gate-run/20260905T201927-86cc29bf/report.json`。新源码的完整发行资格仍待托管验证。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "2d0e8f1c9e4ccb2c4f90c1750bbce032d3cf92cd6d76bb1dee85ad20307e4a48",
+  "openComputeRevision": "1818f51543ed433b060c43badf5901cb41a8c9829d4c8b1ad237d261a2403ebb",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "0a7fcf39a78a34496ba402c18f3ee6875622278a7c38dfd1b47389583b14f6eb",
+  "openComputeRevision": "2d0e8f1c9e4ccb2c4f90c1750bbce032d3cf92cd6d76bb1dee85ad20307e4a48",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {


### PR DESCRIPTION
The macOS release coverage Gate rejected a short-lived `workerd --version` process after it had exited but before it was reaped: `getpgid` failed while `kill(pid, 0)` still succeeded. Use the owned Child's wait status to distinguish this case from a live process. Process-group mismatches, wait errors, version status/output checks and cleanup remain fail-closed; no retries or skipped Gates are added.

A deterministic regression waits with `waitid(EXITED | NOWAIT)` and verifies the macOS syscall behavior, output, exit status and reaping. It passes after the fix; the other 89 runtime unit cases passed. The instrumented stock-workerd `p3-services-events` Gate passes once (6.77 s), as do format, conformance checks and diff checks. Full CI and release qualification remain required. Failed release evidence and both unpublished tag objects are retained.

Issue #4 is already merged and stays included in 0.1.0. Full document parsing remains enabled.
