### PR TITLE
test(r2): remove redundant multipart completion hashing

### DIFF
--- a/crates/artifacts/src/mock_s3.rs
+++ b/crates/artifacts/src/mock_s3.rs
@@ -557,8 +557,8 @@ async fn handle_conn(
             let mut assembled = Vec::new();
             let mut part_digests = Vec::new();
             let part_count = upload.parts.len();
-            for (_number, (_etag, part)) in upload.parts {
-                part_digests.extend_from_slice(&md5::Md5::digest(&part));
+            for (_number, (etag, part)) in upload.parts {
+                part_digests.extend_from_slice(&hex::decode(etag).expect("stored part MD5"));
                 assembled.extend_from_slice(&part);
             }
             let sha256 = hex::encode(Sha256::digest(&assembled));

--- a/crates/artifacts/src/r2_tests/provider_multipart.rs
+++ b/crates/artifacts/src/r2_tests/provider_multipart.rs
@@ -147,27 +147,41 @@ async fn typed_store_round_trips_ssec_storage_class_and_multipart() {
             .unwrap(),
         vec![upload_id.clone()]
     );
-    let part_path = temp.path().join("part");
-    std::fs::write(&part_path, b"part-body").unwrap();
-    std::fs::set_permissions(&part_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-    let part = store
-        .upload_part(
-            &locator,
-            &mpu_key,
-            &upload_id,
-            1,
-            &crate::R2PartSource {
-                path: part_path,
-                length: 9,
-            },
-            None,
-        )
-        .await
-        .unwrap();
+    let mut parts = Vec::new();
+    let mut part_md5s = Vec::new();
+    for (index, body) in [b"part-body".as_slice(), b"tail".as_slice()]
+        .into_iter()
+        .enumerate()
+    {
+        let part_path = temp.path().join(format!("part-{index}"));
+        std::fs::write(&part_path, body).unwrap();
+        std::fs::set_permissions(&part_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        parts.push(
+            store
+                .upload_part(
+                    &locator,
+                    &mpu_key,
+                    &upload_id,
+                    i32::try_from(index + 1).unwrap(),
+                    &crate::R2PartSource {
+                        path: part_path,
+                        length: body.len() as u64,
+                    },
+                    None,
+                )
+                .await
+                .unwrap(),
+        );
+        part_md5s.extend_from_slice(&hash_bytes(body).md5);
+    }
     let completed = store
-        .complete_multipart_upload(&locator, &mpu_key, &upload_id, &[part], None)
+        .complete_multipart_upload(&locator, &mpu_key, &upload_id, &parts, None)
         .await
         .unwrap();
+    assert_eq!(
+        completed.etag,
+        format!("{}-2", hex::encode(Md5::digest(part_md5s)))
+    );
     assert_eq!(completed.key, "mpu.bin");
     assert_eq!(completed.version, version);
     assert_eq!(completed.checksums, R2Checksums::default());

--- a/crates/service/tests/p0_5_r2_support/uploads.rs
+++ b/crates/service/tests/p0_5_r2_support/uploads.rs
@@ -110,8 +110,11 @@ async fn concurrent_large_upload_keeps_runtime_responsive() {
             .unwrap();
     });
     let client = Client::builder(TokioExecutor::new()).build_http::<Body>();
-    let created =
-        checked_json(send(&client, "POST", format!("{base}/create"), Body::empty()).await).await;
+    let created = checked_json(
+        "create",
+        send(&client, "POST", format!("{base}/create"), Body::empty()).await,
+    )
+    .await;
     let upload_id = created["uploadId"].as_str().unwrap().to_owned();
     let repo = R2MultipartRepository::new(gate.storage.db());
     let started = Instant::now();
@@ -124,7 +127,11 @@ async fn concurrent_large_upload_keeps_runtime_responsive() {
                     .await
                     .unwrap();
                 let started = Instant::now();
-                let part = checked_json(send(&client, "PUT", url, Body::from(bytes)).await).await;
+                let part = checked_json(
+                    &format!("upload part {}", index + 1),
+                    send(&client, "PUT", url, Body::from(bytes)).await,
+                )
+                .await;
                 (part, started.elapsed())
             }
         })
@@ -175,11 +182,16 @@ async fn concurrent_large_upload_keeps_runtime_responsive() {
         404,
         "incomplete object must not be visible"
     );
-    let indexed =
-        checked_json(send(&client, "GET", format!("{base}/state"), Body::empty()).await).await;
+    let indexed = checked_json(
+        "D1 state",
+        send(&client, "GET", format!("{base}/state"), Body::empty()).await,
+    )
+    .await;
     assert_eq!(indexed["count"], parts.len());
     assert_eq!(indexed["bytes"], TOTAL);
+    let complete_started = Instant::now();
     let completed = checked_json(
+        "complete multipart",
         send(
             &client,
             "POST",
@@ -189,6 +201,7 @@ async fn concurrent_large_upload_keeps_runtime_responsive() {
         .await,
     )
     .await;
+    let complete_elapsed = complete_started.elapsed();
     assert_eq!(completed["size"], TOTAL);
     assert_eq!(
         repo.get(account, bucket, &upload_id)
@@ -239,13 +252,14 @@ async fn concurrent_large_upload_keeps_runtime_responsive() {
         assert_eq!(provider_parts, parts.len(), "unexpected provider retries");
     }
     println!(
-        "large upload profile={} bytes={TOTAL} concurrency=4 upload_ms={} max_part_ms={} probes={probes} max_probe_ms={} sha256={}",
+        "large upload profile={} bytes={TOTAL} concurrency=4 upload_ms={} complete_ms={} max_part_ms={} probes={probes} max_probe_ms={} sha256={}",
         if cfg!(debug_assertions) {
             "debug"
         } else {
             "release"
         },
         upload_elapsed.as_millis(),
+        complete_elapsed.as_millis(),
         max_part.as_millis(),
         max_probe.as_millis(),
         hex::encode(expected)
@@ -287,7 +301,10 @@ async fn send(
     .unwrap()
 }
 
-async fn checked_json(response: axum::http::Response<hyper::body::Incoming>) -> Value {
+async fn checked_json(
+    operation: &str,
+    response: axum::http::Response<hyper::body::Incoming>,
+) -> Value {
     let status = response.status();
     let text = String::from_utf8(
         response
@@ -299,7 +316,7 @@ async fn checked_json(response: axum::http::Response<hyper::body::Incoming>) -> 
             .to_vec(),
     )
     .unwrap();
-    assert_eq!(status, 200, "{text}");
+    assert_eq!(status, 200, "{operation}: {text}");
     serde_json::from_str(&text).unwrap()
 }
 

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -130,3 +130,34 @@ Linux/macOS 静态检查通过；coverage 的 R2、P2 exit Gate 通过，但 `p3
 单元用例通过，日志保留在 `.temp/release-exit-fix/`。修复后的真实 stock-workerd 插桩
 `p3-services-events` 单轮通过，6.77 s；报告为
 `.temp/gate-run/20260905T201927-86cc29bf/report.json`。新源码的完整发行资格仍待托管验证。
+
+## 第三次发行验证与 S3 夹具的重复摘要计算
+
+[短命子进程修复 PR #8](https://github.com/elliothux/open-compute/pull/8) 已合入
+`2c36a0d52108bbf1f85f58f3fa305180057d5b71`，
+[精确 main CI](https://github.com/elliothux/open-compute/actions/runs/33967204223) 的 49 个进程、
+1,135/1,135 Linux 用例单轮通过，1,035.74 s。重建后的未公开 tag object 为
+`072311df4e00d1d71ce9a09c9787598af2460ec8`。
+
+[第三次发行运行](https://github.com/elliothux/open-compute/actions/runs/33968433021) 的静态检查和
+完整 macOS coverage Gate 已通过：49 个测试进程、1,141/1,141 用例，884.70 s；
+Rust 行覆盖率为 109,609 / 121,720（90.050115%）。报告为
+`.temp/gate-run/20260905T132513-e9dab2d4/report.json`。这份证据属于该次固定输入，不代表随后修改后的
+源码已经重新完成发行资格。
+
+随后 Linux/macOS 非插桩最终 Gate 都在大文件 R2 回归返回 `R2_RESULT_UNKNOWN`，其他目标在失败后
+按规则停止；未打包或公开发布。保留报告
+`.temp/gate-run/failed/20260905T134120-9db263bf/report.json` 与
+`.temp/gate-run/failed/20260905T134137-e7acbe07/report.json`。
+旧日志统一在 `checked_json` 断言，没有标识失败请求阶段，不能据此宣称已直接观察到具体超时调用。
+
+排查发现测试 S3 的 multipart complete 仍重新计算全部分片 MD5，虽然 uploadPart 已保存同一摘要。
+同尺寸一次独立 debug 对比中，旧 assembly/hash 为 4.587 s，复用保存的分片摘要后为 0.711 s，最终
+ETag 与对象 SHA-256 一致。旧耗时已接近夹具的 5 s S3 请求超时，存在随并发负载失败的成本问题。
+修复仅复用夹具已生成的摘要；保留完整对象 SHA-256、真实分片 MD5 和 multipart ETag 算法，
+不更改 production R2、5 s provider fixture timeout、30 s HTTP header deadline 或任何断言门槛。
+
+补充两分片 ETag 回归及请求阶段诊断。修复后的本机非插桩 `p0-5` 两个注册用例单轮通过，56.81 s；
+报告 `.temp/gate-run/20260905T221359-758a8564/report.json`。大文件 upload phase 为 3,756 ms，complete
+为 721 ms，最慢分片 564 ms；52 次轻量请求探测中最慢 112 ms，读回摘要一致。
+源码的托管最终资格与四平台打包仍待完成；旧通过记录和失败记录均保留。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "1818f51543ed433b060c43badf5901cb41a8c9829d4c8b1ad237d261a2403ebb",
+  "openComputeRevision": "6b656535f7af5caf80a6dc1bcc7ebc1a9ebce5d03518fa3ea2337a751934ef56",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {


### PR DESCRIPTION
The large R2 Gate's mock S3 recomputed MD5 over all 231 MiB during multipart completion even though uploadPart already stored those digests. A single debug comparison took 4.587 s with the old assembly/hash path, close to the fixture's 5 s provider timeout; reusing the stored digests took 0.711 s with identical ETag and SHA-256. This excessive fixture work can make qualification depend on runner contention.

Reuse the mock's stored part digests while retaining full-object SHA-256 and the multipart ETag algorithm. Add a two-part ETag regression and identify request stages in failed large-upload assertions. Production R2 code, provider/header deadlines, upload size/concurrency and integrity assertions are unchanged.

Validation: multipart ETag regression passes; uninstrumented real-stock-workerd p0-5 passes both registered cases once (56.81 s). The 231 MiB upload completed its part phase in 3,756 ms and complete in 721 ms; max ping was 112 ms and readback matched. Format, conformance and diff checks pass. Full CI and release qualification are still required; the prior 90.050115% coverage success and both final Gate failures are preserved as evidence for their original source.
