### PR TITLE
fix(runtime): retain Service CONNECT cleanup after disconnect

### DIFF
--- a/crates/service/tests/p3_services_events.rs
+++ b/crates/service/tests/p3_services_events.rs
@@ -187,7 +187,7 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
         .unwrap();
     assert_eq!(queue.outcome, "ok");
     assert!(queue.ack_all);
-    wait_service_drain(&harness).await;
+    wait_service_drain(&harness, "queue").await;
 
     let scheduled = harness
         .transport
@@ -205,7 +205,7 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
         .unwrap();
     assert_eq!(scheduled.outcome, "ok");
     assert!(scheduled.no_retry);
-    wait_service_drain(&harness).await;
+    wait_service_drain(&harness, "cron").await;
 
     let response = harness
         .transport
@@ -224,7 +224,7 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
     let body = to_bytes(response.into_body(), 1024).await.unwrap();
     assert_eq!(status, 200, "unexpected DO response: {body:?}");
     assert_eq!(body.as_ref(), b"service:do");
-    wait_service_drain(&harness).await;
+    wait_service_drain(&harness, "do").await;
 
     let workflow_target = WorkflowTarget {
         account_id: account,
@@ -270,7 +270,7 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
         }
         outcome => panic!("unexpected Workflow outcome: {outcome:?}"),
     }
-    wait_service_drain(&harness).await;
+    wait_service_drain(&harness, "workflow").await;
     harness.stop().await;
 }
 
@@ -365,12 +365,12 @@ fn dispatch_target(
     }
 }
 
-async fn wait_service_drain(harness: &Harness) {
+async fn wait_service_drain(harness: &Harness, source: &str) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while harness.service_invocations.counts() != (0, 0, 0) {
         assert!(
             Instant::now() < deadline,
-            "Service event root did not drain: {:?}",
+            "Service {source} event root did not drain: {:?}",
             harness.service_invocations.counts()
         );
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/docs/acceptance/first-release-0.1.0.md
+++ b/docs/acceptance/first-release-0.1.0.md
@@ -161,3 +161,29 @@ ETag 与对象 SHA-256 一致。旧耗时已接近夹具的 5 s S3 请求超时�
 报告 `.temp/gate-run/20260905T221359-758a8564/report.json`。大文件 upload phase 为 3,756 ms，complete
 为 721 ms，最慢分片 564 ms；52 次轻量请求探测中最慢 112 ms，读回摘要一致。
 源码的托管最终资格与四平台打包仍待完成；旧通过记录和失败记录均保留。
+
+
+## Service CONNECT 清理任务的生命周期
+
+[夹具摘要修复 PR #9](https://github.com/elliothux/open-compute/pull/9) 已合入
+`c3bdee434ff127af69ec377b7cc33a4ecb6d018b`。PR 单轮 Linux workspace 通过，精确 main
+[CI 33972774162](https://github.com/elliothux/open-compute/actions/runs/33972774162) 的 R2 Gate
+通过（60.82 s），但 `p3-services-events` 在成功返回后的 drain 检查失败：30 s 后仍有
+1 个 root、1 个 operation、0 个 retention。旧断言没有记录事件来源，不能从该日志判断是
+Queue、Cron、DO 还是 Workflow。保留 `.temp/gate-run/failed/20260905T145343-9892cab5/report.json`，
+没有重跑失败输入或移动发行 tag。
+
+当前 pin 的 workerd `io/worker-entrypoint.c++` CONNECT 取消路径会 drain 已注册的 waitUntil
+任务；`api/global-scope.c++` 的原始 handler promise 自身不提供同等保活。Service transport
+原先只 await tunnel 和 finally 中的 registry finalize，连接关闭可能使该请求上下文先结束。
+现将整个处理 promise 在入口同步注册到 `ctx.waitUntil`，覆盖 admission、tunnel 和原子 finalize；
+继续返回同一 promise，保留失败传播、有限重试、半关闭语义和版本 pin。没有提前释放仍在使用的
+operation，也没有放宽 30 s drain 检查。现有四事件真实 Gate 补充来源标签。
+
+三个确定性 TypeScript 回归验证成功、断连、最终清理失败时，同一 promise 在首次 await 前已注册，
+且 registry finalize 返回前不会结算；和已有重试回归合计 4/4 通过。完整 JS CI 用例 218/218、
+`bun run build`、runtime typecheck、Rust format 和 diff 检查通过。本机真实 Gate 在离线构建前
+因 Cargo archive cache 缺少 `adler2 v2.0.1` 终止，没有执行用例；保留
+`.temp/gate-run/failed/20260905T232407-11f5f43a/report.json`，真实 stock-workerd 验证交给托管 CI。
+新的完整发行资格尚待验证。该修改只涉及平台内部生命周期，不更改 Cloudflare 公开类型或协议；
+未运行真实 Cloudflare hosted differential。

--- a/packages/runtime/src/services/transport.ts
+++ b/packages/runtime/src/services/transport.ts
@@ -491,7 +491,14 @@ export class ServiceTransport extends WorkerEntrypoint<LoaderEnv, ServiceBinding
     return this.#invoke(frame, property, [], true);
   }
 
-  async connect(socket: Socket): Promise<void> {
+  connect(socket: Socket): Promise<void> {
+    const completion = this.#connect(socket);
+    // Native CONNECT cancellation must not discard the registry finalization request.
+    this.ctx.waitUntil(completion);
+    return completion;
+  }
+
+  async #connect(socket: Socket): Promise<void> {
     let admitted: ServiceAdmission | undefined;
     const frame = Object.freeze({ scopeId: crypto.randomUUID(), parentFrame: null });
     try {

--- a/packages/runtime/tests/services/transport.test.mjs
+++ b/packages/runtime/tests/services/transport.test.mjs
@@ -4,7 +4,9 @@ import { compileRuntime, moduleUrl } from "../compiled-runtime.mjs";
 
 const cloudflare = moduleUrl(`
   export class RpcTarget {}
-  export class WorkerEntrypoint {}
+  export class WorkerEntrypoint {
+    constructor(ctx, env) { this.ctx = ctx; this.env = env; }
+  }
   export function waitUntil() {}
 `);
 const inert = moduleUrl(`
@@ -12,7 +14,8 @@ const inert = moduleUrl(`
   export const tenantEnv = () => ({});
   export const modulesFor = () => ({});
   export const inboundSocketTargetAddress = async () => "example.invalid:443";
-  export const tunnelSockets = async () => {};
+  export const tunnelControl = { run: async () => {} };
+  export const tunnelSockets = (...args) => tunnelControl.run(...args);
   export const assembleOnce = async (_key, factory) => factory();
   export const bindingError = code => new Error(code);
   export const BINDING_TOKEN_HEADER = "x-binding-token";
@@ -21,7 +24,7 @@ const inert = moduleUrl(`
   export const doPolicy = () => ({});
   export const INTERNAL_HEADERS = [];
   export const lockWorkerCode = () => ({});
-  export const resolveSnapshot = async () => ({});
+  export const resolveSnapshot = async () => ({ routeGeneration: 1, contentKind: "worker" });
   export const tenantGlobalOutbound = () => ({});
 `);
 
@@ -36,7 +39,7 @@ const transportUrl = moduleUrl(await compileRuntime("services/transport.ts", {
   "../sockets/tunnel.js": inert,
   "../loader/shared.js": inert,
 }));
-const { retryServiceControl } = await import(transportUrl);
+const { ServiceTransport, retryServiceControl } = await import(transportUrl);
 
 test("Service lifecycle mutations retry transient private-hop failures", async () => {
   let calls = 0;
@@ -58,3 +61,59 @@ test("Service lifecycle mutations retry transient private-hop failures", async (
   );
   assert.equal(calls, 3);
 });
+
+const { tunnelControl } = await import(inert);
+
+for (const outcome of ["success", "disconnect", "finalization failure"]) {
+  test(`Service CONNECT keeps ${outcome} cleanup alive after caller disconnect`, async () => {
+    const finalizing = Promise.withResolvers();
+    const finish = Promise.withResolvers();
+    const background = [];
+    let finalizeCalls = 0;
+    let closes = 0;
+    tunnelControl.run = async () => {
+      if (outcome === "disconnect") throw new Error("socket disconnected");
+    };
+    const ctx = {
+      props: { versionId: "version", bindingName: "TARGET", descriptorSha256: "a".repeat(64) },
+      waitUntil(task) { background.push(task); },
+    };
+    const env = {
+      LOADER: { get() { return { getEntrypoint() {
+        return { connect() { return { opened: Promise.resolve() }; } };
+      } }; } },
+      BINDING_BACKEND_TOKEN: "token",
+      BINDING_BACKEND: { async fetch(url) {
+        if (url.endsWith("/resolve")) return Response.json({
+          handle: "operation", frame: "callee", callerFrame: "caller", deadlineMs: 30000,
+          target: { loaderKey: "account/worker/version", workerCodeSha256: "a".repeat(64),
+            routeGeneration: 1, contentKind: "worker" },
+        });
+        assert.ok(url.endsWith("/connect/finalize"));
+        finalizeCalls += 1;
+        finalizing.resolve();
+        await finish.promise;
+        if (outcome === "finalization failure") throw new Error("private hop failed");
+        return Response.json({ ok: true });
+      } },
+    };
+    const completion = new ServiceTransport(ctx, env).connect({
+      close: async () => { closes += 1; },
+    });
+    assert.deepEqual(background, [completion], "register before the caller can disconnect");
+    let settled = false;
+    const observed = completion.then(
+      () => { settled = true; return null; },
+      error => { settled = true; return error; },
+    );
+    await finalizing.promise;
+    assert.equal(settled, false, "retained task includes the awaited registry finalization");
+    finish.resolve();
+    const error = await observed;
+    assert.equal(finalizeCalls, outcome === "finalization failure" ? 3 : 1);
+    assert.equal(closes, outcome === "disconnect" ? 1 : 0);
+    if (outcome === "success") assert.equal(error, null);
+    else assert.match(error.message,
+      outcome === "disconnect" ? /SERVICE_UNAVAILABLE/ : /private hop failed/);
+  });
+}

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "6b656535f7af5caf80a6dc1bcc7ebc1a9ebce5d03518fa3ea2337a751934ef56",
+  "openComputeRevision": "6833e3ec0e957d6f200c9ffd54fc3c0eb3ac0822e607546acf2aab8644183384",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "4ccb7814a1ec72f50a3862cfac7475be6a4cade0ca646e8d16a2cb9aac42cb0f",
   "workerd": {


### PR DESCRIPTION
Native Service CONNECT cancellation can end the request context while its registry finalization is still pending, leaving a root and operation after the socket has closed. Register the full connection task with `ctx.waitUntil` before the first await, and return that same promise so admission, tunneling, finalization and errors retain their existing semantics.

Add success, disconnect and finalization-failure lifecycle tests and label the four event-source drain assertions. Keep half-close behavior, finite retries, version pins and the 30-second drain assertion unchanged.

Validation: build, runtime typecheck, 218 JS CI tests, Rust format and diff checks passed. Local real-runtime Gate could not build offline because the Cargo archive cache is missing adler2; no cases executed. Hosted CI must verify the full workspace. Preserve the failed main CI evidence and update the release qualification record.
