### PR TITLE
docs: Compatibility 100% + CF module coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,27 +77,56 @@ Compatibility here is measured, not asserted. The same fixtures run against open
 
 ## Compatibility
 
-Write standard module workers (`export default { fetch }`) with the bindings you already know:
+Write standard module workers (`export default { fetch }`) with the bindings you already know.
 
-| Module | Progress |
+### Runtime & bindings
+
+| Module | Status |
 | --- | --- |
-| Workers | █████████░ 95% |
-| KV | █████████░ 95% |
-| R2 | █████████░ 95% |
-| D1 | █████████░ 95% |
-| Durable Objects | █████████░ 95% |
-| Queues | █████████░ 95% |
-| Cron | █████████░ 95% |
-| Workflows | █████████░ 95% |
-| Static Assets | █████████░ 95% |
-| Service Bindings | █████████░ 95% |
-| Cache | █████████░ 95% |
-| Images | █████████░ 95% |
-| Version Metadata | ██████████ 100% |
-| WebSocket Hibernation | ██████████ 100% |
-| Cloudflare v4 · Wrangler · Dashboard | Core implemented; hosted qualification tracked separately |
+| Workers | ✅ 100% |
+| KV | ✅ 100% |
+| R2 | ✅ 100% |
+| D1 | ✅ 100% |
+| Durable Objects | ✅ 100% |
+| Queues | ✅ 100% |
+| Cron | ✅ 100% |
+| Workflows | ✅ 100% |
+| Static Assets | ✅ 100% |
+| Service Bindings | ✅ 100% |
+| Cache | ✅ 100% |
+| Images | ✅ 100% |
+| Version Metadata | ✅ 100% |
+| WebSocket Hibernation | ✅ 100% |
 
-The remaining 5% is single-node reality — global edge topology and hosted fleet quotas — not missing methods. Exact scope: [compatibility matrix](docs/references/cloudflare-compatibility.md) · `ocd capabilities --json`
+### Management
+
+| Surface | Status |
+| --- | --- |
+| Cloudflare v4 API | Implemented locally (`/client/v4`; P6 gates). Hosted differential qualification may still need credentials. |
+| Wrangler | 4.127.1 — resource/deploy commands gated against live `ocd` |
+| Dashboard | Operator / SDK-backed admin UI available — not a Cloudflare dashboard clone |
+| Workers Logs / realtime tail | Implemented locally (P7 Script Tails + Telemetry events/invocations subset; single-node `observability.sqlite`) |
+
+### Not yet / partial
+
+| Module | Status |
+| --- | --- |
+| Vectorize | Partial — stable post-beta `Vectorize` API; beta `VectorizeIndex` out of scope |
+| Workers AI / Markdown / AI Search | Partial — standard `env.AI` for Markdown Conversion + AI Search with operator-configured OpenAI-compatible providers; **full Workers AI model inference not provided** |
+| Browser Run | Not yet (design; formerly Browser Rendering) |
+| Artifacts | Not yet (design) |
+| Containers | Not yet |
+| Hyperdrive | Not yet |
+| Analytics Engine | Not yet |
+| Workers for Platforms | Not yet |
+| Dynamic Workers | Not yet |
+| Pipelines | Not yet |
+| Rate Limiting | Not yet |
+| mTLS certificates | Not yet |
+| Full Workers AI inference | Not yet |
+| Tail Workers / traces export / Logpush | Not yet |
+
+✅ means no missing Worker/product methods; single-node topology deviations are documented in the [compatibility matrix](docs/references/cloudflare-compatibility.md). Live surface: `ocd capabilities --json`.
 
 ## Quick start
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,28 +81,56 @@ open-compute **就是这一层**——而且只有**一个文件**。
 
 ## 兼容性
 
-编写标准 module worker（`export default { fetch }`），使用你已熟悉的 binding：
+编写标准 module worker（`export default { fetch }`），使用你已熟悉的 binding。
 
-| 模块 | 进度 |
+### 运行时与 binding
+
+| 模块 | 状态 |
 | --- | --- |
-| Workers | █████████░ 95% |
-| KV | █████████░ 95% |
-| R2 | █████████░ 95% |
-| D1 | █████████░ 95% |
-| Durable Objects | █████████░ 95% |
-| Queues | █████████░ 95% |
-| Cron | █████████░ 95% |
-| Workflows | █████████░ 95% |
-| Static Assets | █████████░ 95% |
-| Service Bindings | █████████░ 95% |
-| Cache | █████████░ 95% |
-| Images | █████████░ 95% |
-| Version Metadata | ██████████ 100% |
-| WebSocket Hibernation | ██████████ 100% |
-| Cloudflare v4 · Wrangler · Dashboard | 核心已实现；托管端资格单独跟踪 |
+| Workers | ✅ 100% |
+| KV | ✅ 100% |
+| R2 | ✅ 100% |
+| D1 | ✅ 100% |
+| Durable Objects | ✅ 100% |
+| Queues | ✅ 100% |
+| Cron | ✅ 100% |
+| Workflows | ✅ 100% |
+| Static Assets | ✅ 100% |
+| Service Bindings | ✅ 100% |
+| Cache | ✅ 100% |
+| Images | ✅ 100% |
+| Version Metadata | ✅ 100% |
+| WebSocket Hibernation | ✅ 100% |
 
-剩下的 5% 是单节点的客观现实——全球边缘拓扑与托管 fleet 配额——不是缺方法。
-精确支持面：[兼容矩阵](docs/references/cloudflare-compatibility.md) · `ocd capabilities --json`
+### 管理面
+
+| 表面 | 状态 |
+| --- | --- |
+| Cloudflare v4 API | 本地 `/client/v4` 已实现（P6 Gate）。托管端差分资格可能仍缺凭证。 |
+| Wrangler | 4.127.1 — 资源/部署命令已对 live `ocd` 做 Gate |
+| Dashboard | 提供 operator / SDK 支撑的管理 UI——不是 Cloudflare Dashboard 克隆 |
+| Workers Logs / realtime tail | 本地已实现（P7 Script Tails + Telemetry events/invocations 子集；单机 `observability.sqlite`） |
+
+### 尚未支持 / 部分支持
+
+| 模块 | 状态 |
+| --- | --- |
+| Vectorize | 部分 — 稳定后 beta 的 `Vectorize` API；beta `VectorizeIndex` 不在范围 |
+| Workers AI / Markdown / AI Search | 部分 — 标准 `env.AI` 覆盖 Markdown Conversion 与 AI Search（operator 配置的 OpenAI-compatible provider）；**不提供完整 Workers AI 模型推理** |
+| Browser Run | 尚未（设计中；原 Browser Rendering） |
+| Artifacts | 尚未（设计中） |
+| Containers | 尚未 |
+| Hyperdrive | 尚未 |
+| Analytics Engine | 尚未 |
+| Workers for Platforms | 尚未 |
+| Dynamic Workers | 尚未 |
+| Pipelines | 尚未 |
+| Rate Limiting | 尚未 |
+| mTLS certificates | 尚未 |
+| 完整 Workers AI 推理 | 尚未 |
+| Tail Workers / traces export / Logpush | 尚未 |
+
+✅ 表示 Worker/产品方法无缺口；单机拓扑差异见[兼容矩阵](docs/references/cloudflare-compatibility.md)。运行中表面：`ocd capabilities --json`。
 
 ## 快速开始
 

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -31,6 +31,7 @@ type Copy = {
   storage: string;
   compute: string;
   media: string;
+  ai: string;
   compatibility: string;
   deviations: string;
   unsupported: string;
@@ -77,6 +78,7 @@ const zhCopy: Copy = {
   storage: "存储",
   compute: "计算",
   media: "媒体",
+  ai: "AI",
   compatibility: "兼容性",
   deviations: "行为差异",
   unsupported: "不支持",
@@ -123,6 +125,7 @@ const enCopy: Copy = {
   storage: "Storage",
   compute: "Compute",
   media: "Media",
+  ai: "AI",
   compatibility: "Compatibility",
   deviations: "Behavior differences",
   unsupported: "Unsupported",
@@ -225,6 +228,7 @@ function sidebar(prefix: string, t: Copy): DefaultTheme.SidebarItem[] {
         productTree(prefix, t, "kv", "KV"),
         productTree(prefix, t, "d1", "D1"),
         productTree(prefix, t, "r2", "R2"),
+        productTree(prefix, t, "vectorize", "Vectorize"),
       ],
     },
     {
@@ -240,6 +244,10 @@ function sidebar(prefix: string, t: Copy): DefaultTheme.SidebarItem[] {
     {
       text: t.media,
       items: [productTree(prefix, t, "images", "Images")],
+    },
+    {
+      text: t.ai,
+      items: [productTree(prefix, t, "ai-search", "AI Search")],
     },
     {
       text: t.platform,

--- a/packages/docs/ai-search/concepts/index.md
+++ b/packages/docs/ai-search/concepts/index.md
@@ -1,0 +1,26 @@
+# Concepts
+
+AI Search separates:
+
+- **Namespace** — catalog of instances (parent resource; no per-namespace database)
+- **Instance** — one SQLite authority plus immutable source objects on the configured Local or S3 backend
+- **`env.AI`** — platform binding for Markdown Conversion only (`toMarkdown` / `supported` / `aiGatewayLogId`)
+
+Indexing pipeline: upload → parse (document parser child) → chunk → embed (operator provider) → FTS + vector generations. Search modes: keyword, vector, and hybrid. Chat uses retrieval plus an optional generation provider; SSE streaming is supported when configured.
+
+Providers are pinned by the operator (model revision, dimensions, tokenizer digest, timeouts). open-compute does not ship embedded model weights or claim Cloudflare-hosted model availability.
+
+Not provided:
+
+- Full Workers AI inference (`run`, `models`, AutoRAG, unrelated `env.AI` members)
+- Cloudflare-hosted automatic provider selection, billing, dashboard connectors
+- Global index placement / replication
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| Data path | Hosted AI Search | Per-instance SQLite + Local/S3 objects |
+| Models | Workers AI | Operator OpenAI-compatible endpoints |
+| Markdown Conversion | `env.AI.toMarkdown` | Same subset |
+| Full Workers AI | Available | Not provided |

--- a/packages/docs/ai-search/examples/index.md
+++ b/packages/docs/ai-search/examples/index.md
@@ -1,0 +1,36 @@
+# Examples
+
+Upload a document, then hybrid-search and convert Markdown with `env.AI`.
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/upload" && request.method === "PUT") {
+      const name = url.searchParams.get("name") ?? "upload.bin";
+      return Response.json(await env.SEARCH.items.upload(name, await request.blob()));
+    }
+    if (url.pathname === "/search") {
+      const q = url.searchParams.get("q") ?? "";
+      return Response.json(await env.SEARCH.search({ query: q }));
+    }
+    if (url.pathname === "/markdown" && request.method === "POST") {
+      return Response.json(
+        await env.AI.toMarkdown({ name: "body.html", blob: await request.blob() }),
+      );
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<{ SEARCH: AiSearchInstance; AI: Ai }>;
+```
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+Setup: [Get started](/ai-search/get-started/). Options: [Guides](/ai-search/guides/).

--- a/packages/docs/ai-search/get-started/index.md
+++ b/packages/docs/ai-search/get-started/index.md
@@ -1,0 +1,57 @@
+# Get started
+
+`ocd` must be ready. The operator must configure OpenAI-compatible embedding (and optional rewrite / rerank / chat) providers in the platform config before AI Search can index or answer.
+
+## 1. Create namespace and instance
+
+Use pinned Wrangler against live `ocd` (commands follow Cloudflare AI Search / Wrangler resource flow).
+
+## 2. Declare bindings
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+```sh
+bun run oc types --config wrangler.jsonc
+```
+
+## 3. Upload and search
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "PUT") {
+      const file = await request.blob();
+      const item = await env.SEARCH.items.upload("guide.pdf", file);
+      return Response.json(item);
+    }
+    return Response.json(await env.SEARCH.search({ query: "how does cache work?" }));
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+Upload returns quickly with a queued item; parse / chunk / embed / index continue asynchronously on the node.
+
+## 4. Markdown Conversion
+
+```ts
+const formats = await env.AI.supported();
+const md = await env.AI.toMarkdown({ name: "page.html", blob: htmlBlob });
+```
+
+`env.AI.run()`, `models()`, gateway, AutoRAG, and other inference members are rejected.
+
+## 5. Deploy
+
+```sh
+bun run oc deploy --config wrangler.jsonc
+```
+
+Next: [Concepts](/ai-search/concepts/).

--- a/packages/docs/ai-search/guides/index.md
+++ b/packages/docs/ai-search/guides/index.md
@@ -1,0 +1,48 @@
+# Guides
+
+## Bindings
+
+```json
+"ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+"ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+"ai": { "binding": "AI" }
+```
+
+Namespace bindings can create/list instances in that namespace. Instance bindings talk to one fixed instance.
+
+## Items and jobs
+
+```ts
+await env.SEARCH.items.upload("notes.md", blob);
+await env.SEARCH.items.list();
+await env.SEARCH.jobs.list();
+```
+
+## Search and chat
+
+```ts
+await env.SEARCH.search({
+  query: "durable objects alarms",
+  ai_search_options: { retrieval: { max_num_results: 10 } },
+});
+
+await env.SEARCH.chatCompletions({
+  messages: [{ role: "user", content: "Summarize cache behavior" }],
+  stream: true,
+});
+```
+
+Multi-instance search/chat goes through the namespace binding with `ai_search_options.instance_ids`.
+
+## Markdown Conversion
+
+```ts
+await env.AI.toMarkdown(
+  { name: "spec.pdf", blob },
+  { conversionOptions: { output: { format: "markdown" }, pdf: { metadata: true } } },
+);
+```
+
+Admitted formats include text, Markdown, HTML, XML, JSON, CSV, text-layer PDF, and common Office/ODF spreadsheets/documents. Images/OCR and unsupported Office variants fail closed.
+
+Official docs: [AI Search](https://developers.cloudflare.com/ai-search/).

--- a/packages/docs/ai-search/index.md
+++ b/packages/docs/ai-search/index.md
@@ -1,0 +1,54 @@
+# AI Search
+
+AI Search indexes files you upload, then runs keyword, vector, or hybrid retrieval and optional chat. Markdown Conversion is exposed on the same standard `env.AI` binding via `toMarkdown()` / `supported()`.
+
+open-compute implements these surfaces with **operator-configured OpenAI-compatible providers**. Full Workers AI model inference (`run()`, `models()`, AutoRAG, and unrelated inference) is **not** provided.
+
+For example, you can use AI Search for:
+
+- Uploading documents and searching them from a Worker
+- Hybrid retrieval before generating an answer
+- Converting Office/PDF/HTML inputs to Markdown with `env.AI.toMarkdown()`
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const result = await env.SEARCH.search({ query: "cache invalidation" });
+    return Response.json(result);
+  },
+} satisfies ExportedHandler<{ SEARCH: AiSearchInstance }>;
+```
+
+Bind a namespace and/or instance, plus the platform `ai` binding when you need Markdown Conversion:
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+Official reference: [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/). Binding grammar: [bindings](/workers/configuration/bindings).
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| AI Search Worker API | Namespace / instance / items / jobs / search / chat | Same declared surface |
+| Markdown Conversion | `env.AI.toMarkdown()` / `supported()` | Same pinned overloads |
+| Embeddings / chat models | Cloudflare-hosted Workers AI | Operator-pinned OpenAI-compatible providers |
+| Full Workers AI inference | `run()` / `models()` / AutoRAG | **Not provided** |
+| Object bytes | Hosted storage | Selected Local or S3 authority |
+| Placement / replication | Global | Single-node |
+
+## Next
+
+- [Get started](/ai-search/get-started/)
+- [Concepts](/ai-search/concepts/)
+- [Guides](/ai-search/guides/)
+- [Examples](/ai-search/examples/)
+- [Limits](/ai-search/platform/limits)
+- [Behavior differences](/ai-search/platform/deviations)

--- a/packages/docs/ai-search/platform/deviations.md
+++ b/packages/docs/ai-search/platform/deviations.md
@@ -1,0 +1,16 @@
+# Behavior differences
+
+AI Search and Markdown Conversion run on one node with operator-owned model endpoints.
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| AI Search API | Namespace / instance / items / jobs / search / chat | Same declared surface |
+| Models | Hosted Workers AI | Operator-configured OpenAI-compatible providers |
+| Objects | Hosted storage | Local or S3 authority selected by the operator |
+| Markdown Conversion | `env.AI.toMarkdown` | Same subset; local tokenizer estimate |
+| Full Workers AI / AutoRAG | Available | Not provided |
+| Global placement | Available | Not provided |
+
+See [Compatibility](/platform/compatibility), [Unsupported](/platform/unsupported), and [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/).

--- a/packages/docs/ai-search/platform/limits.md
+++ b/packages/docs/ai-search/platform/limits.md
@@ -1,0 +1,11 @@
+# Limits
+
+Declared Worker/API ceilings include: AI Search item and `toMarkdown` file ≤ 4 MiB; `toMarkdown` batch ≤ 16 files / 32 MiB input; per-file Markdown output ≤ 16 MiB; multi-instance request ≤ 10 instances; custom metadata fields ≤ 5; search results typically 1–50; context expansion 0–3.
+
+Local quotas also bound items/chunks/vectors per instance, indexing jobs, provider concurrency, request/response bytes, and stream counts. Parser child defaults include a 30s deadline and bounded address/CPU/stderr. Live numbers:
+
+```sh
+ocd capabilities --json
+```
+
+These are not Cloudflare AI Search plan quotas. Full Workers AI inference limits do not apply because that surface is not provided.

--- a/packages/docs/directory.md
+++ b/packages/docs/directory.md
@@ -19,9 +19,13 @@ open-compute provides the products below. The Worker API matches Cloudflare's do
 | [Workers Cache](/workers/cache/) | Automatic HTTP cache for Worker responses |
 | [Cache API](/workers/runtime-apis/cache) | `caches.default` and friends |
 | [Images](/images/) | Bounded local raster transforms |
+| [Vectorize](/vectorize/) | Stable post-beta vector index binding (exact search) |
+| [AI Search](/ai-search/) | AI Search + Markdown Conversion via `env.AI` (operator-configured providers) |
 | [Version Metadata](/workers/runtime-apis/bindings) | Immutable deployment `id` / `tag` / `timestamp` |
 | [WebSocket hibernation](/workers/runtime-apis/websockets) | Hibernatable WebSockets on Durable Objects |
 
 Alarms live under Durable Objects. Cron lives under Workers configuration. Platform notes: [Platform](/platform/). Worker API signatures: [API reference](/platform/reference/api/).
+
+Management surfaces (separate from product bindings): local Cloudflare v4 `/client/v4`, pinned Wrangler 4.127.1, and the operator / SDK-backed dashboard — see [Compatibility](/platform/compatibility).
 
 Cloudflare products that are not provided: [Unsupported](/platform/unsupported).

--- a/packages/docs/platform/compatibility.md
+++ b/packages/docs/platform/compatibility.md
@@ -31,6 +31,8 @@ Worker-side signatures: [Workers runtime APIs](https://developers.cloudflare.com
 | [Service Bindings](/workers/runtime-apis/bindings) | `Fetcher` | Same platform; no cross-region discovery |
 | [Deployments](/workers/versions-and-deployments/) | Versions, promotion, rollback | Local SQLite and one runtime generation |
 | [Images](/images/) | Images binding | Bounded local raster transforms; not hosted Cloudflare Images |
+| [Vectorize](/vectorize/) | Stable post-beta `Vectorize` | Local exact search; per-index SQLite; beta `VectorizeIndex` out of scope |
+| [AI Search](/ai-search/) | `env.AI` Markdown Conversion + AI Search | Operator-configured OpenAI-compatible providers; full Workers AI inference not provided |
 | [Version Metadata](/workers/runtime-apis/bindings) | Deployment `id` / `tag` / `timestamp` | Produced by local deploy authority |
 | [WebSocket hibernation](/workers/runtime-apis/websockets) | Hibernatable WebSockets | On the local Durable Object process |
 
@@ -39,5 +41,18 @@ D1 covers database / session / prepared statement / result / meta, errors and bi
 ## Runtime
 
 The platform freezes the compatibility date. `wrangler.jsonc` cannot set `compatibilityDate` or flags. Use `runtime.effective_compatibility_date`. Do not swap a workerd beside the binary, search `PATH`, or download another runtime.
+
+## Management
+
+Management surfaces are separate from product bindings. Keep them distinct:
+
+| Surface | Status |
+| --- | --- |
+| Cloudflare v4 API | Local `/client/v4` implemented (P6 gates). Hosted differential qualification may still need credentials. |
+| Wrangler | Pinned 4.127.1 — resource/deploy commands gated against live `ocd` |
+| Dashboard | Operator / SDK-backed admin UI — not a Cloudflare dashboard clone |
+| Workers Logs / realtime tail | Implemented locally (P7 Script Tails + Telemetry events/invocations subset; single-node `observability.sqlite`). Tail Workers, traces export, and Logpush are not provided. |
+
+## Unsupported
 
 Products that are not provided: [Unsupported](/platform/unsupported). Operators can inspect the running binary with `ocd capabilities --json`.

--- a/packages/docs/platform/unsupported.md
+++ b/packages/docs/platform/unsupported.md
@@ -1,16 +1,23 @@
 # Unsupported
 
-open-compute does not provide the following Cloudflare products. The deployment authority rejects them at the boundary. Do not treat a name in upstream types as an injected binding.
+open-compute rejects the Cloudflare developer-platform products below at the deployment authority boundary. Do not treat a name in upstream types as an injected binding.
 
-| Name | Cloudflare product |
-| --- | --- |
-| `analytics_engine` | Analytics Engine |
-| `ai` | Workers AI |
-| `browser_rendering` | Browser Rendering |
-| `vectorize` | Vectorize |
-| `hyperdrive` | Hyperdrive |
-| `mtls` | mTLS certificates |
-| `rate_limiting` | Rate Limiting |
-| `workers_for_platforms` | Workers for Platforms |
+Partial surfaces that **are** provided (with documented limits) live on their product pages: [Vectorize](/vectorize/), [AI Search](/ai-search/) (includes Markdown Conversion via `env.AI`). Full Workers AI model inference is **not** provided.
+
+| Name / config field | Cloudflare product | Status |
+| --- | --- | --- |
+| `browser` / `browser_rendering` | [Browser Run](https://developers.cloudflare.com/browser-rendering/) (formerly Browser Rendering) | Not yet — design only ([P12](https://github.com/elliothux/open-compute/blob/main/docs/p12-browser-run.md)) |
+| `artifacts` | Artifacts | Not yet — design only ([P11](https://github.com/elliothux/open-compute/blob/main/docs/p11-cloudflare-artifacts.md)) |
+| `containers` / `cloudchamber` | Containers | Not yet |
+| `hyperdrive` | Hyperdrive | Not yet |
+| `analytics_engine` / `analytics_engine_datasets` | Analytics Engine | Not yet |
+| `workers_for_platforms` / `dispatch_namespaces` | Workers for Platforms | Not yet |
+| `worker_loaders` | Dynamic Workers | Not yet |
+| `pipelines` | Pipelines | Not yet |
+| `rate_limiting` / `ratelimits` | Rate Limiting | Not yet |
+| `mtls` / `mtls_certificates` | mTLS certificates | Not yet |
+| Workers AI `run()` / `models()` / AutoRAG / unrelated inference | Full Workers AI model inference | Not yet — see [AI Search](/ai-search/) for the declared `env.AI` subset |
+
+Pure edge/topology gaps (Anycast, global replication, hosted fleet quotas) are not listed here as missing products; see [Behavior differences](/platform/deviations).
 
 The provided surface is the [Directory](/directory) and [Compatibility](/platform/compatibility).

--- a/packages/docs/vectorize/concepts/index.md
+++ b/packages/docs/vectorize/concepts/index.md
@@ -1,0 +1,23 @@
+# Concepts
+
+Each public index is one local SQLite authority. Mutations (`insert` / `upsert` / `deleteByIds`) are durable and asynchronous: the Worker receives a `mutationId`; applied visibility advances through the local coordinator. Queries (`query` / `queryById` / `getByIds` / `describe`) read the applied frontier.
+
+Search is **exact** (full scan with metadata pre-filter), not Cloudflare's distributed approximate topology. Scores follow the index metric: cosine, euclidean, or dot-product.
+
+Metadata filters use the indexed metadata surface (`$eq`, `$ne`, `$in`, `$nin`, `$lt`, `$lte`, `$gt`, `$gte`, and combinations). Create metadata indexes before filtering on a property, matching Cloudflare's contract.
+
+Not provided:
+
+- Deprecated beta `VectorizeIndex` class
+- Hosted global placement / replication
+- Cloudflare dashboard billing or fleet-scale quotas (for example 10M–20M vectors/index as a local promise)
+- Automatic embedding generation (use your model or [AI Search](/ai-search/))
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| Index authority | Managed Vectorize service | Per-index local SQLite |
+| Query algorithm | Approximate / distributed | Exact / local |
+| Async mutations | `mutationId` | Same public shape; local durable coordinator |
+| Beta `VectorizeIndex` | Legacy | Not provided |

--- a/packages/docs/vectorize/examples/index.md
+++ b/packages/docs/vectorize/examples/index.md
@@ -1,0 +1,35 @@
+# Examples
+
+Upsert vectors, then query nearest neighbors with a metadata filter.
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/upsert" && request.method === "POST") {
+      const vectors = await request.json<VectorizeVector[]>();
+      return Response.json(await env.VECTORIZE.upsert(vectors));
+    }
+    if (url.pathname === "/query" && request.method === "POST") {
+      const vector = await request.json<number[]>();
+      const { matches } = await env.VECTORIZE.query(vector, {
+        topK: 5,
+        filter: { published: true },
+        returnMetadata: "all",
+      });
+      return Response.json(matches);
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<{ VECTORIZE: Vectorize }>;
+```
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+Setup: [Get started](/vectorize/get-started/). Options: [Guides](/vectorize/guides/).

--- a/packages/docs/vectorize/get-started/index.md
+++ b/packages/docs/vectorize/get-started/index.md
@@ -1,0 +1,56 @@
+# Get started
+
+`ocd` must be ready. Create a Vectorize index, then bind it from `wrangler.jsonc`.
+
+## 1. Create an index
+
+Use pinned Wrangler against live `ocd` (or the local Cloudflare v4 API):
+
+```sh
+wrangler vectorize create embeddings --dimensions=768 --metric=cosine
+```
+
+## 2. Declare the binding
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+```sh
+bun run oc types --config wrangler.jsonc
+```
+
+## 3. Worker
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "PUT") {
+      const body = await request.json<{ id: string; values: number[] }>();
+      const { mutationId } = await env.VECTORIZE.upsert([
+        { id: body.id, values: body.values, metadata: { source: "api" } },
+      ]);
+      return Response.json({ mutationId });
+    }
+    const { matches } = await env.VECTORIZE.query(
+      await request.json<number[]>(),
+      { topK: 10, returnMetadata: "all" },
+    );
+    return Response.json(matches);
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+You supply vectors; open-compute does not generate embeddings. For document ingest + embedding + retrieval, see [AI Search](/ai-search/).
+
+## 4. Deploy
+
+```sh
+bun run oc deploy --config wrangler.jsonc
+```
+
+Next: [Concepts](/vectorize/concepts/).

--- a/packages/docs/vectorize/guides/index.md
+++ b/packages/docs/vectorize/guides/index.md
@@ -1,0 +1,46 @@
+# Guides
+
+## Bind an index
+
+```json
+"vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+```
+
+`index_name` must resolve to an existing index in the same account.
+
+## Insert and upsert
+
+```ts
+await env.VECTORIZE.insert([
+  { id: "doc-1", values: embedding, namespace: "docs", metadata: { lang: "en" } },
+]);
+await env.VECTORIZE.upsert([
+  { id: "doc-1", values: embedding, metadata: { lang: "en", rev: 2 } },
+]);
+```
+
+`insert` does not overwrite an existing id. `upsert` replaces the full vector record. Batches are capped (see [Limits](/vectorize/platform/limits)).
+
+## Query with metadata
+
+```ts
+const { matches } = await env.VECTORIZE.query(embedding, {
+  topK: 20,
+  namespace: "docs",
+  filter: { lang: "en", year: { $gte: 2024 } },
+  returnValues: false,
+  returnMetadata: "indexed",
+});
+```
+
+`returnMetadata`: `"none"` | `"indexed"` | `"all"` (boolean `true` normalizes to `"all"`).
+
+## queryById / getByIds / describe
+
+```ts
+await env.VECTORIZE.queryById("doc-1", { topK: 5 });
+await env.VECTORIZE.getByIds(["doc-1", "doc-2"]);
+const info = await env.VECTORIZE.describe();
+```
+
+Official API: [Vectorize Workers API](https://developers.cloudflare.com/vectorize/reference/client-api/).

--- a/packages/docs/vectorize/index.md
+++ b/packages/docs/vectorize/index.md
@@ -1,0 +1,53 @@
+# Vectorize
+
+Vectorize is a vector index binding for Workers. Store embeddings you already computed, filter by metadata, and run similarity queries. open-compute implements the stable post-beta [`Vectorize`](https://developers.cloudflare.com/vectorize/) API with deterministic **exact** search on one node.
+
+For example, you can use Vectorize for:
+
+- Semantic search over document embeddings
+- Recommendation / nearest-neighbor lookups from a Worker
+- Metadata-filtered retrieval before an LLM call
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { matches } = await env.VECTORIZE.query([0.12, 0.34, /* … */], {
+      topK: 5,
+      returnMetadata: "indexed",
+    });
+    return Response.json(matches);
+  },
+} satisfies ExportedHandler<{ VECTORIZE: Vectorize }>;
+```
+
+Create an index (Wrangler or v4), then bind it:
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+Official reference: [Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/). Binding grammar: [bindings](/workers/configuration/bindings).
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| Worker API | Stable post-beta `Vectorize` (`describe` / `query` / `queryById` / `insert` / `upsert` / `deleteByIds` / `getByIds`) | Same methods and response shape |
+| Search | Managed approximate / distributed index | Deterministic **exact** search on one node |
+| Dimensions / metrics | 32–1536; cosine, euclidean, dot-product | Same public ranges and score/order semantics |
+| Mutations | Asynchronous `mutationId` | Durable async mutations on local authority |
+| Beta `VectorizeIndex` | Legacy | Out of scope — not provided |
+| Placement / replication | Global | Single-node; Local/S3 as configured by the operator |
+
+## Next
+
+- [Get started](/vectorize/get-started/)
+- [Concepts](/vectorize/concepts/)
+- [Guides](/vectorize/guides/)
+- [Examples](/vectorize/examples/)
+- [Limits](/vectorize/platform/limits)
+- [Behavior differences](/vectorize/platform/deviations)

--- a/packages/docs/vectorize/platform/deviations.md
+++ b/packages/docs/vectorize/platform/deviations.md
@@ -1,0 +1,16 @@
+# Behavior differences
+
+Vectorize on open-compute is a single-node exact index, not Cloudflare's globally distributed Vectorize service.
+
+## Compatibility
+
+| Topic | Cloudflare | open-compute |
+| --- | --- | --- |
+| Worker API | Stable post-beta `Vectorize` | Same public methods |
+| Search | Managed approximate topology | Deterministic exact search |
+| Storage | Hosted Vectorize | Per-index local SQLite; Local/S3 as needed for platform object backends |
+| Beta `VectorizeIndex` | Legacy | Not provided |
+| Global placement / replication | Available | Not provided |
+| Fleet-scale quotas | Hosted plans | Local create-time quotas |
+
+See [Compatibility](/platform/compatibility) and [Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/).

--- a/packages/docs/vectorize/platform/limits.md
+++ b/packages/docs/vectorize/platform/limits.md
@@ -1,0 +1,11 @@
+# Limits
+
+Worker API ceilings follow Cloudflare Vectorize where declared: dimensions 32–1536 (float32), vector id and namespace ≤ 64 UTF-8 bytes, metadata ≤ 10 KiB/vector, ≤ 10 metadata indexes per index, mutation batch ≤ 1000, `topK` ≤ 100 (≤ 50 with values or all metadata).
+
+Local resource quotas are operator-owned and frozen at index create time. Embedded defaults include on the order of **100k vectors/index** (schema ceiling lower than Cloudflare's hosted multi-million scale) plus a logical bytes quota and bounded CPU concurrency. Live numbers:
+
+```sh
+ocd capabilities --json
+```
+
+These are not Cloudflare plan quotas. Approximate ANN capacity (hosted 10M+/index class) is not provided.

--- a/packages/docs/workers/runtime-apis/index.md
+++ b/packages/docs/workers/runtime-apis/index.md
@@ -30,7 +30,8 @@ export default {
 | --- | --- | --- |
 | `fetch` / Request / Response / Streams / HTMLRewriter / Web Crypto / RPC | Yes | Yes |
 | Alarms, Version Metadata, WebSocket hibernation | Yes | Yes |
-| Workers AI / Vectorize and other non-platform products | Yes | Not provided |
+| Vectorize / AI Search (`env.AI` Markdown subset) | Yes | Yes — see [Vectorize](/vectorize/) and [AI Search](/ai-search/); full Workers AI inference not provided |
+| Other non-platform products (Browser Run, Hyperdrive, …) | Yes | Not provided — see [Unsupported](/platform/unsupported) |
 | Outbound TCP / `fetch` network policy | Cloudflare hosted policy | See [TCP sockets](/workers/runtime-apis/tcp-sockets) |
 | Request-scoped CPU / subrequest quotas | Yes | See [Limits](/workers/platform/limits) |
 

--- a/packages/docs/zh/ai-search/concepts/index.md
+++ b/packages/docs/zh/ai-search/concepts/index.md
@@ -1,0 +1,26 @@
+# 概念
+
+AI Search 区分：
+
+- **Namespace** — instance 目录（父资源；不单独建库）
+- **Instance** — 一份 SQLite authority，外加配置的 Local 或 S3 后端上的不可变源对象
+- **`env.AI`** — 仅用于 Markdown Conversion 的平台 binding（`toMarkdown` / `supported` / `aiGatewayLogId`）
+
+索引流水线：上传 → 解析（文档 parser 子进程）→ chunk → embed（operator provider）→ FTS 与向量 generation。检索模式：关键词、向量、混合。Chat 在检索后可选调用 generation provider；配置齐全时可 SSE 流式输出。
+
+Provider 由 operator 固定（模型 revision、维度、tokenizer digest、超时）。open-compute 不内嵌模型权重，也不声称 Cloudflare 托管模型可用。
+
+不提供：
+
+- 完整 Workers AI 推理（`run`、`models`、AutoRAG、其它无关 `env.AI` 成员）
+- Cloudflare 托管的自动 provider 选择、计费、Dashboard 连接器
+- 全球索引就近存放 / 复制
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| 数据路径 | 托管 AI Search | 每 instance 一份 SQLite + Local/S3 对象 |
+| 模型 | Workers AI | operator 的 OpenAI-compatible 端点 |
+| Markdown Conversion | `env.AI.toMarkdown` | 同一子集 |
+| 完整 Workers AI | 提供 | 不提供 |

--- a/packages/docs/zh/ai-search/examples/index.md
+++ b/packages/docs/zh/ai-search/examples/index.md
@@ -1,0 +1,36 @@
+# 示例
+
+上传文档后做混合检索，并用 `env.AI` 做 Markdown 转换。
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/upload" && request.method === "PUT") {
+      const name = url.searchParams.get("name") ?? "upload.bin";
+      return Response.json(await env.SEARCH.items.upload(name, await request.blob()));
+    }
+    if (url.pathname === "/search") {
+      const q = url.searchParams.get("q") ?? "";
+      return Response.json(await env.SEARCH.search({ query: q }));
+    }
+    if (url.pathname === "/markdown" && request.method === "POST") {
+      return Response.json(
+        await env.AI.toMarkdown({ name: "body.html", blob: await request.blob() }),
+      );
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<{ SEARCH: AiSearchInstance; AI: Ai }>;
+```
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+上手见[上手](/zh/ai-search/get-started/)。选项见[指南](/zh/ai-search/guides/)。

--- a/packages/docs/zh/ai-search/get-started/index.md
+++ b/packages/docs/zh/ai-search/get-started/index.md
@@ -1,0 +1,57 @@
+# 上手
+
+需要 `ocd` 就绪。在 AI Search 能够建索引或回答之前，operator 须在平台配置中写好 OpenAI-compatible 的 embedding（以及可选的 rewrite / rerank / chat）provider。
+
+## 1. 创建 namespace 与 instance
+
+对 live `ocd` 使用固定 Wrangler（命令遵循 Cloudflare AI Search / Wrangler 资源流程）。
+
+## 2. 声明 binding
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+```sh
+bun run oc types --config wrangler.jsonc
+```
+
+## 3. 上传与检索
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "PUT") {
+      const file = await request.blob();
+      const item = await env.SEARCH.items.upload("guide.pdf", file);
+      return Response.json(item);
+    }
+    return Response.json(await env.SEARCH.search({ query: "how does cache work?" }));
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+上传快速返回 queued item；parse / chunk / embed / index 在本机异步继续。
+
+## 4. Markdown Conversion
+
+```ts
+const formats = await env.AI.supported();
+const md = await env.AI.toMarkdown({ name: "page.html", blob: htmlBlob });
+```
+
+`env.AI.run()`、`models()`、gateway、AutoRAG 及其它推理成员会被拒绝。
+
+## 5. 部署
+
+```sh
+bun run oc deploy --config wrangler.jsonc
+```
+
+下一步：[概念](/zh/ai-search/concepts/)。

--- a/packages/docs/zh/ai-search/guides/index.md
+++ b/packages/docs/zh/ai-search/guides/index.md
@@ -1,0 +1,48 @@
+# 指南
+
+## Binding
+
+```json
+"ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+"ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+"ai": { "binding": "AI" }
+```
+
+Namespace binding 可在该 namespace 内创建/列出 instance。Instance binding 只能访问固定 instance。
+
+## Items 与 jobs
+
+```ts
+await env.SEARCH.items.upload("notes.md", blob);
+await env.SEARCH.items.list();
+await env.SEARCH.jobs.list();
+```
+
+## 检索与 chat
+
+```ts
+await env.SEARCH.search({
+  query: "durable objects alarms",
+  ai_search_options: { retrieval: { max_num_results: 10 } },
+});
+
+await env.SEARCH.chatCompletions({
+  messages: [{ role: "user", content: "Summarize cache behavior" }],
+  stream: true,
+});
+```
+
+多 instance 的 search/chat 通过 namespace binding，并传入 `ai_search_options.instance_ids`。
+
+## Markdown Conversion
+
+```ts
+await env.AI.toMarkdown(
+  { name: "spec.pdf", blob },
+  { conversionOptions: { output: { format: "markdown" }, pdf: { metadata: true } } },
+);
+```
+
+已接纳格式包括文本、Markdown、HTML、XML、JSON、CSV、文本层 PDF，以及常见 Office/ODF 表格与文档。图像/OCR 与不支持的 Office 变体会失败关闭。
+
+官方文档：[AI Search](https://developers.cloudflare.com/ai-search/)。

--- a/packages/docs/zh/ai-search/index.md
+++ b/packages/docs/zh/ai-search/index.md
@@ -1,0 +1,54 @@
+# AI Search
+
+AI Search 对你上传的文件建索引，并支持关键词、向量或混合检索以及可选的 chat。Markdown Conversion 通过同一标准 `env.AI` binding 的 `toMarkdown()` / `supported()` 提供。
+
+open-compute 使用 **operator 配置的 OpenAI-compatible provider** 实现上述表面。**不提供**完整 Workers AI 模型推理（`run()`、`models()`、AutoRAG 及其它无关推理）。
+
+例如可用于：
+
+- 上传文档并在 Worker 中检索
+- 在生成回答前做混合检索
+- 使用 `env.AI.toMarkdown()` 将 Office/PDF/HTML 转为 Markdown
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const result = await env.SEARCH.search({ query: "cache invalidation" });
+    return Response.json(result);
+  },
+} satisfies ExportedHandler<{ SEARCH: AiSearchInstance }>;
+```
+
+绑定 namespace 和/或 instance；需要 Markdown Conversion 时再声明平台 `ai` binding：
+
+```json
+{
+  "name": "search-app",
+  "main": "src/index.ts",
+  "ai_search_namespaces": [{ "binding": "SEARCH_NS", "namespace": "team" }],
+  "ai_search": [{ "binding": "SEARCH", "instance_name": "docs" }],
+  "ai": { "binding": "AI" }
+}
+```
+
+官方文档：[Cloudflare AI Search](https://developers.cloudflare.com/ai-search/)。绑定语法见[绑定](/zh/workers/configuration/bindings)。
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| AI Search Worker API | Namespace / instance / items / jobs / search / chat | 已声明表面相同 |
+| Markdown Conversion | `env.AI.toMarkdown()` / `supported()` | 固定 overload 相同 |
+| Embedding / chat 模型 | Cloudflare 托管 Workers AI | operator 固定的 OpenAI-compatible provider |
+| 完整 Workers AI 推理 | `run()` / `models()` / AutoRAG | **不提供** |
+| 对象字节 | 托管存储 | 选定的 Local 或 S3 authority |
+| 就近存放 / 复制 | 全球 | 单机 |
+
+## 本节
+
+- [上手](/zh/ai-search/get-started/)
+- [概念](/zh/ai-search/concepts/)
+- [指南](/zh/ai-search/guides/)
+- [示例](/zh/ai-search/examples/)
+- [限制](/zh/ai-search/platform/limits)
+- [行为差异](/zh/ai-search/platform/deviations)

--- a/packages/docs/zh/ai-search/platform/deviations.md
+++ b/packages/docs/zh/ai-search/platform/deviations.md
@@ -1,0 +1,16 @@
+# 行为差异
+
+AI Search 与 Markdown Conversion 运行在单机上，模型端点由 operator 持有。
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| AI Search API | Namespace / instance / items / jobs / search / chat | 已声明表面相同 |
+| 模型 | 托管 Workers AI | operator 配置的 OpenAI-compatible provider |
+| 对象 | 托管存储 | operator 选定的 Local 或 S3 authority |
+| Markdown Conversion | `env.AI.toMarkdown` | 同一子集；本机 tokenizer 估算 |
+| 完整 Workers AI / AutoRAG | 提供 | 不提供 |
+| 全球就近存放 | 提供 | 不提供 |
+
+见[兼容性](/zh/platform/compatibility)、[不支持](/zh/platform/unsupported)与 [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/)。

--- a/packages/docs/zh/ai-search/platform/limits.md
+++ b/packages/docs/zh/ai-search/platform/limits.md
@@ -1,0 +1,11 @@
+# 限制
+
+已声明的 Worker/API 上限包括：AI Search item 与 `toMarkdown` 单文件 ≤ 4 MiB；`toMarkdown` 批次 ≤ 16 个文件 / 32 MiB 输入；单文件 Markdown 输出 ≤ 16 MiB；多 instance 请求 ≤ 10 个 instance；自定义 metadata 字段 ≤ 5；检索结果通常 1–50；context expansion 0–3。
+
+本机配额还约束每 instance 的 items/chunks/vectors、indexing jobs、provider 并发、请求/响应字节与流数量。Parser 子进程默认含 30s 截止与有界地址/CPU/stderr。运行中数值：
+
+```sh
+ocd capabilities --json
+```
+
+这些不是 Cloudflare AI Search 套餐配额。因不提供完整 Workers AI 推理，对应推理限额不适用。

--- a/packages/docs/zh/directory.md
+++ b/packages/docs/zh/directory.md
@@ -19,9 +19,13 @@ open-compute 提供下列产品。Worker API 与 Cloudflare 文档一致；数�
 | [Workers Cache](/zh/workers/cache/) | Worker 响应的 HTTP 缓存 |
 | [Cache API](/zh/workers/runtime-apis/cache) | `caches.default` 等 |
 | [Images](/zh/images/) | 本地图像变换（受尺寸与并发限制） |
+| [Vectorize](/zh/vectorize/) | 稳定后 beta 的向量索引 binding（精确检索） |
+| [AI Search](/zh/ai-search/) | AI Search 与经 `env.AI` 的 Markdown Conversion（operator 配置的 provider） |
 | [Version Metadata](/zh/workers/runtime-apis/bindings) | 部署的 `id` / `tag` / `timestamp` |
 | [WebSocket hibernation](/zh/workers/runtime-apis/websockets) | Durable Object 上可休眠的 WebSocket |
 
 Alarms 归入 Durable Objects。Cron 归入 Workers 配置。平台说明见[平台](/zh/platform/)。API 签名见 [API 参考](/zh/platform/reference/api/)。
+
+管理面（与产品 binding 分开）：本地 Cloudflare v4 `/client/v4`、固定 Wrangler 4.127.1，以及 operator / SDK 支撑的 Dashboard — 见[兼容性](/zh/platform/compatibility)。
 
 未提供的 Cloudflare 产品见[不支持](/zh/platform/unsupported)。

--- a/packages/docs/zh/platform/compatibility.md
+++ b/packages/docs/zh/platform/compatibility.md
@@ -31,6 +31,8 @@ Worker 签名以 [Workers runtime APIs](https://developers.cloudflare.com/worker
 | [Service Bindings](/zh/workers/runtime-apis/bindings) | `Fetcher` | 同一平台内；不提供跨地区发现 |
 | [Deployments](/zh/workers/versions-and-deployments/) | 版本、发布与回滚 | 本机 SQLite；`ocd` 监督当前 workerd 进程 |
 | [Images](/zh/images/) | Images 绑定 | 本机图像变换；不是托管 Cloudflare Images |
+| [Vectorize](/zh/vectorize/) | 稳定后 beta 的 `Vectorize` | 本机精确检索；每索引一份 SQLite；beta `VectorizeIndex` 不在范围 |
+| [AI Search](/zh/ai-search/) | `env.AI` Markdown Conversion 与 AI Search | operator 配置的 OpenAI-compatible provider；不提供完整 Workers AI 推理 |
 | [Version Metadata](/zh/workers/runtime-apis/bindings) | 部署的 `id` / `tag` / `timestamp` | 由本机本次部署生成 |
 | [WebSocket hibernation](/zh/workers/runtime-apis/websockets) | 可休眠 WebSocket | 本机 Durable Object 进程 |
 
@@ -39,5 +41,18 @@ D1 覆盖 database / session / prepared statement / result / meta、错误与 bi
 ## 运行时
 
 兼容日期由平台锁定，`wrangler.jsonc` 不得设置 `compatibilityDate` 或 flags。以 `runtime.effective_compatibility_date` 为准。不要替换二进制旁的 workerd，也不要从 `PATH` 另行解析 runtime。
+
+## 管理面
+
+管理面与产品 binding 分开，请分别看待：
+
+| 表面 | 状态 |
+| --- | --- |
+| Cloudflare v4 API | 本地 `/client/v4` 已实现（P6 Gate）。托管端差分资格可能仍缺凭证。 |
+| Wrangler | 固定 4.127.1 — 资源/部署命令已对 live `ocd` 做 Gate |
+| Dashboard | operator / SDK 支撑的管理 UI——不是 Cloudflare Dashboard 克隆 |
+| Workers Logs / realtime tail | 本地已实现（P7 Script Tails + Telemetry events/invocations 子集；单机 `observability.sqlite`）。不提供 Tail Workers、traces export、Logpush。 |
+
+## 不支持
 
 未提供的产品见[不支持](/zh/platform/unsupported)。运维可通过 `ocd capabilities --json` 查看运行中的二进制。

--- a/packages/docs/zh/platform/unsupported.md
+++ b/packages/docs/zh/platform/unsupported.md
@@ -1,16 +1,23 @@
 # 不支持
 
-open-compute 不提供下列 Cloudflare 产品。部署时会在边界拒绝它们。不要仅因 upstream types 中存在同名符号，就将其视为已注入的 binding。
+open-compute 在部署 authority 边界拒绝下列 Cloudflare 开发者平台产品。不要仅因 upstream types 中存在同名符号，就将其视为已注入的 binding。
 
-| 名称 | Cloudflare 产品 |
-| --- | --- |
-| `analytics_engine` | Analytics Engine |
-| `ai` | Workers AI |
-| `browser_rendering` | Browser Rendering |
-| `vectorize` | Vectorize |
-| `hyperdrive` | Hyperdrive |
-| `mtls` | mTLS certificates |
-| `rate_limiting` | Rate Limiting |
-| `workers_for_platforms` | Workers for Platforms |
+**已提供、但有边界** 的产品见对应文档：[Vectorize](/zh/vectorize/)、[AI Search](/zh/ai-search/)（含经 `env.AI` 的 Markdown Conversion）。**不提供**完整 Workers AI 模型推理。
+
+| 名称 / 配置字段 | Cloudflare 产品 | 状态 |
+| --- | --- | --- |
+| `browser` / `browser_rendering` | [Browser Run](https://developers.cloudflare.com/browser-rendering/)（原 Browser Rendering） | 尚未 — 仅设计（[P12](https://github.com/elliothux/open-compute/blob/main/docs/p12-browser-run.md)） |
+| `artifacts` | Artifacts | 尚未 — 仅设计（[P11](https://github.com/elliothux/open-compute/blob/main/docs/p11-cloudflare-artifacts.md)） |
+| `containers` / `cloudchamber` | Containers | 尚未 |
+| `hyperdrive` | Hyperdrive | 尚未 |
+| `analytics_engine` / `analytics_engine_datasets` | Analytics Engine | 尚未 |
+| `workers_for_platforms` / `dispatch_namespaces` | Workers for Platforms | 尚未 |
+| `worker_loaders` | Dynamic Workers | 尚未 |
+| `pipelines` | Pipelines | 尚未 |
+| `rate_limiting` / `ratelimits` | Rate Limiting | 尚未 |
+| `mtls` / `mtls_certificates` | mTLS certificates | 尚未 |
+| Workers AI `run()` / `models()` / AutoRAG / 其它推理 | 完整 Workers AI 模型推理 | 尚未 — 已声明的 `env.AI` 子集见 [AI Search](/zh/ai-search/) |
+
+纯边缘/拓扑差异（Anycast、全球复制、托管 fleet 配额）不作为“缺产品”列出，见[行为差异](/zh/platform/deviations)。
 
 已提供的产品见[产品目录](/zh/directory)和[兼容性](/zh/platform/compatibility)。

--- a/packages/docs/zh/vectorize/concepts/index.md
+++ b/packages/docs/zh/vectorize/concepts/index.md
@@ -1,0 +1,23 @@
+# 概念
+
+每个公开索引对应一份本机 SQLite authority。Mutation（`insert` / `upsert` / `deleteByIds`）持久且异步：Worker 收到 `mutationId`，applied 可见性由本地 coordinator 推进。查询（`query` / `queryById` / `getByIds` / `describe`）读取已应用的 frontier。
+
+检索为**精确**检索（带 metadata 预过滤的全量扫描），不是 Cloudflare 的分布式近似拓扑。分数遵循索引度量：cosine、euclidean 或 dot-product。
+
+Metadata 过滤使用已索引的 metadata 表面（`$eq`、`$ne`、`$in`、`$nin`、`$lt`、`$lte`、`$gt`、`$gte` 及组合）。过滤某属性前需先创建 metadata index，与 Cloudflare 合同一致。
+
+不提供：
+
+- 已弃用的 beta `VectorizeIndex` 类
+- 托管全球就近存放 / 复制
+- Cloudflare 计费或舰队级配额（例如将 1000 万–2000 万向量/索引作为本地承诺）
+- 自动 embedding 生成（使用自有模型或 [AI Search](/zh/ai-search/)）
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| 索引 authority | 托管 Vectorize 服务 | 每索引一份本机 SQLite |
+| 查询算法 | 近似 / 分布式 | 精确 / 本机 |
+| 异步 mutation | `mutationId` | 公开形状相同；本机持久 coordinator |
+| Beta `VectorizeIndex` | 遗留 | 不提供 |

--- a/packages/docs/zh/vectorize/examples/index.md
+++ b/packages/docs/zh/vectorize/examples/index.md
@@ -1,0 +1,35 @@
+# 示例
+
+写入向量后，按 metadata 过滤查询近邻。
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/upsert" && request.method === "POST") {
+      const vectors = await request.json<VectorizeVector[]>();
+      return Response.json(await env.VECTORIZE.upsert(vectors));
+    }
+    if (url.pathname === "/query" && request.method === "POST") {
+      const vector = await request.json<number[]>();
+      const { matches } = await env.VECTORIZE.query(vector, {
+        topK: 5,
+        filter: { published: true },
+        returnMetadata: "all",
+      });
+      return Response.json(matches);
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<{ VECTORIZE: Vectorize }>;
+```
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+上手见[上手](/zh/vectorize/get-started/)。选项见[指南](/zh/vectorize/guides/)。

--- a/packages/docs/zh/vectorize/get-started/index.md
+++ b/packages/docs/zh/vectorize/get-started/index.md
@@ -1,0 +1,56 @@
+# 上手
+
+需要 `ocd` 就绪。先创建 Vectorize 索引，再在 `wrangler.jsonc` 中绑定。
+
+## 1. 创建索引
+
+对 live `ocd` 使用固定 Wrangler（或本地 Cloudflare v4 API）：
+
+```sh
+wrangler vectorize create embeddings --dimensions=768 --metric=cosine
+```
+
+## 2. 声明 binding
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+```sh
+bun run oc types --config wrangler.jsonc
+```
+
+## 3. Worker
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "PUT") {
+      const body = await request.json<{ id: string; values: number[] }>();
+      const { mutationId } = await env.VECTORIZE.upsert([
+        { id: body.id, values: body.values, metadata: { source: "api" } },
+      ]);
+      return Response.json({ mutationId });
+    }
+    const { matches } = await env.VECTORIZE.query(
+      await request.json<number[]>(),
+      { topK: 10, returnMetadata: "all" },
+    );
+    return Response.json(matches);
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+向量由你提供；open-compute 不负责生成 embedding。文档入库 + embedding + 检索见 [AI Search](/zh/ai-search/)。
+
+## 4. 部署
+
+```sh
+bun run oc deploy --config wrangler.jsonc
+```
+
+下一步：[概念](/zh/vectorize/concepts/)。

--- a/packages/docs/zh/vectorize/guides/index.md
+++ b/packages/docs/zh/vectorize/guides/index.md
@@ -1,0 +1,46 @@
+# 指南
+
+## 绑定索引
+
+```json
+"vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+```
+
+`index_name` 必须解析为同一账号内已存在的索引。
+
+## insert 与 upsert
+
+```ts
+await env.VECTORIZE.insert([
+  { id: "doc-1", values: embedding, namespace: "docs", metadata: { lang: "en" } },
+]);
+await env.VECTORIZE.upsert([
+  { id: "doc-1", values: embedding, metadata: { lang: "en", rev: 2 } },
+]);
+```
+
+`insert` 不覆盖已有 id。`upsert` 替换完整向量记录。批次上限见[限制](/zh/vectorize/platform/limits)。
+
+## 带 metadata 的查询
+
+```ts
+const { matches } = await env.VECTORIZE.query(embedding, {
+  topK: 20,
+  namespace: "docs",
+  filter: { lang: "en", year: { $gte: 2024 } },
+  returnValues: false,
+  returnMetadata: "indexed",
+});
+```
+
+`returnMetadata`：`"none"` | `"indexed"` | `"all"`（布尔 `true` 归一为 `"all"`）。
+
+## queryById / getByIds / describe
+
+```ts
+await env.VECTORIZE.queryById("doc-1", { topK: 5 });
+await env.VECTORIZE.getByIds(["doc-1", "doc-2"]);
+const info = await env.VECTORIZE.describe();
+```
+
+官方 API：[Vectorize Workers API](https://developers.cloudflare.com/vectorize/reference/client-api/)。

--- a/packages/docs/zh/vectorize/index.md
+++ b/packages/docs/zh/vectorize/index.md
@@ -1,0 +1,53 @@
+# Vectorize
+
+Vectorize 是 Workers 的向量索引 binding。写入你已计算好的 embedding，按 metadata 过滤，并做相似度查询。open-compute 实现稳定后 beta 的 [`Vectorize`](https://developers.cloudflare.com/vectorize/) API，在单机上提供确定性的**精确**检索。
+
+例如可用于：
+
+- 文档 embedding 的语义检索
+- 从 Worker 发起推荐 / 近邻查询
+- 在调用 LLM 前做带 metadata 过滤的检索
+
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { matches } = await env.VECTORIZE.query([0.12, 0.34, /* … */], {
+      topK: 5,
+      returnMetadata: "indexed",
+    });
+    return Response.json(matches);
+  },
+} satisfies ExportedHandler<{ VECTORIZE: Vectorize }>;
+```
+
+创建索引（Wrangler 或 v4）后绑定：
+
+```json
+{
+  "name": "vector-app",
+  "main": "src/index.ts",
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "embeddings" }]
+}
+```
+
+官方文档：[Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/)。绑定语法见[绑定](/zh/workers/configuration/bindings)。
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| Worker API | 稳定后 beta 的 `Vectorize`（`describe` / `query` / `queryById` / `insert` / `upsert` / `deleteByIds` / `getByIds`） | 方法与响应形状相同 |
+| 检索 | 托管近似 / 分布式索引 | 单机确定性**精确**检索 |
+| 维度 / 度量 | 32–1536；cosine、euclidean、dot-product | 公开范围与 score/order 语义相同 |
+| Mutation | 异步 `mutationId` | 本地 authority 上的持久异步 mutation |
+| Beta `VectorizeIndex` | 遗留 | 不在范围 — 不提供 |
+| 就近存放 / 复制 | 全球 | 单机；按 operator 配置使用 Local/S3 |
+
+## 本节
+
+- [上手](/zh/vectorize/get-started/)
+- [概念](/zh/vectorize/concepts/)
+- [指南](/zh/vectorize/guides/)
+- [示例](/zh/vectorize/examples/)
+- [限制](/zh/vectorize/platform/limits)
+- [行为差异](/zh/vectorize/platform/deviations)

--- a/packages/docs/zh/vectorize/platform/deviations.md
+++ b/packages/docs/zh/vectorize/platform/deviations.md
@@ -1,0 +1,16 @@
+# 行为差异
+
+open-compute 上的 Vectorize 是单机精确索引，不是 Cloudflare 全球分布式 Vectorize 服务。
+
+## 兼容性
+
+| 主题 | Cloudflare | open-compute |
+| --- | --- | --- |
+| Worker API | 稳定后 beta 的 `Vectorize` | 公开方法相同 |
+| 检索 | 托管近似拓扑 | 确定性精确检索 |
+| 存储 | 托管 Vectorize | 每索引本机 SQLite；平台对象后端按需使用 Local/S3 |
+| Beta `VectorizeIndex` | 遗留 | 不提供 |
+| 全球就近存放 / 复制 | 提供 | 不提供 |
+| 舰队级配额 | 托管套餐 | 本机创建时配额 |
+
+见[兼容性](/zh/platform/compatibility)与 [Cloudflare Vectorize](https://developers.cloudflare.com/vectorize/)。

--- a/packages/docs/zh/vectorize/platform/limits.md
+++ b/packages/docs/zh/vectorize/platform/limits.md
@@ -1,0 +1,11 @@
+# 限制
+
+Worker API 上限在已声明处与 Cloudflare Vectorize 对齐：维度 32–1536（float32），向量 id 与 namespace ≤ 64 UTF-8 字节，metadata ≤ 10 KiB/向量，每索引 ≤ 10 个 metadata index，mutation 批次 ≤ 1000，`topK` ≤ 100（返回 values 或全部 metadata 时 ≤ 50）。
+
+本机资源配额由 operator 管理，并在创建索引时冻结。内嵌默认约为 **每索引 10 万向量**（schema 上限低于 Cloudflare 托管的百万级规模），另有逻辑字节配额与有界 CPU 并发。运行中数值：
+
+```sh
+ocd capabilities --json
+```
+
+这些不是 Cloudflare 套餐配额。近似 ANN 容量（托管千万级/索引一类）不提供。

--- a/packages/docs/zh/workers/runtime-apis/index.md
+++ b/packages/docs/zh/workers/runtime-apis/index.md
@@ -30,7 +30,8 @@ export default {
 | --- | --- | --- |
 | `fetch` / Request / Response / Streams / HTMLRewriter / Web Crypto / RPC | 是 | 是 |
 | Alarms、Version Metadata、WebSocket hibernation | 是 | 是 |
-| Workers AI / Vectorize 等非本平台产品 | 是 | 不提供 |
+| Vectorize / AI Search（`env.AI` Markdown 子集） | 是 | 是 — 见 [Vectorize](/zh/vectorize/) 与 [AI Search](/zh/ai-search/)；不提供完整 Workers AI 推理 |
+| 其它非本平台产品（Browser Run、Hyperdrive 等） | 是 | 不提供 — 见[不支持](/zh/platform/unsupported) |
 | 出站 TCP / `fetch` 网络策略 | Cloudflare 托管策略 | 见 [TCP sockets](/zh/workers/runtime-apis/tcp-sockets) |
 | 请求级 CPU / subrequest 配额 | 是 | 见 [限制](/zh/workers/platform/limits) |
 


### PR DESCRIPTION
## Summary

- Resolve README / README.zh Compatibility conflicts by keeping ✅ 100% rows for full API modules (not 95% bars); keep v4 / Wrangler / Dashboard as three separate Management rows (not a Cloudflare dashboard clone).
- Document Workers Logs / realtime tail as implemented locally (P7 Script Tails + Telemetry events/invocations subset; single-node `observability.sqlite`); leave Tail Workers / traces export / Logpush in Not yet.
- Move Vectorize and AI Search (Markdown Conversion via `env.AI`) out of unsupported product list into product docs; fix unsupported design links to P12 Browser Run and P11 Artifacts.
- Add lean EN+ZH product trees for `/vectorize/` and `/ai-search/` (index, get-started, concepts, guides, examples, platform limits/deviations); wire VitePress storage + AI sidebars.
- Update platform compatibility pages with Vectorize / AI Search rows and a short Management section.

## Test plan

- [x] `cd packages/docs && bun run build` (ignoreDeadLinks: false) — passed
- [ ] Spot-check README Compatibility / Management / Not yet tables EN+ZH
- [ ] Spot-check Vectorize and AI Search sidebar pages EN+ZH