### PR TITLE
release: require operator-focused release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
+      notes: ${{ steps.release.outputs.notes }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -67,10 +68,38 @@ jobs:
             echo "tag $tag does not match workspace version $version" >&2
             exit 1
           fi
+          notes="docs/implemented/release-$version.md"
+          if [ ! -f "$notes" ] || [ -L "$notes" ]; then
+            echo "release notes must be a checked-in regular file at $notes" >&2
+            exit 1
+          fi
+          if [ "$(wc -c < "$notes" | tr -d ' ')" -lt 1000 ]; then
+            echo "release notes must contain at least 1000 bytes of substantive content" >&2
+            exit 1
+          fi
+          for heading in \
+            "## What's new" \
+            "## Fixed" \
+            "## Before you upgrade" \
+            "## Install or upgrade" \
+            "## Downloads" \
+            "## Security" \
+            "## Known limitations" \
+            "## Verification"; do
+            if ! grep -Fqx "$heading" "$notes"; then
+              echo "release notes are missing required heading: $heading" >&2
+              exit 1
+            fi
+          done
+          if grep -Eiq '(^|[^A-Za-z])(TODO|TBD|PLACEHOLDER)([^A-Za-z]|$)' "$notes"; then
+            echo "release notes contain an unfinished placeholder" >&2
+            exit 1
+          fi
           test -z "$(git status --porcelain --untracked-files=all)"
           {
             echo "tag=$tag"
             echo "version=$version"
+            echo "notes=$notes"
           } >> "$GITHUB_OUTPUT"
 
       - name: Require successful main pre-check for the release source commit
@@ -348,6 +377,7 @@ jobs:
       contents: write
       actions: read
     steps:
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           name: public-release
@@ -358,6 +388,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_NOTES: ${{ needs.validate.outputs.notes }}
         run: |
           set -euo pipefail
           assets="$GITHUB_WORKSPACE/.temp/release-assets"
@@ -372,7 +403,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --draft \
-            --generate-notes \
+            --notes-file "$GITHUB_WORKSPACE/$RELEASE_NOTES" \
             --title "open-compute $RELEASE_VERSION"
           verify="$RUNNER_TEMP/release-download"
           mkdir "$verify"

--- a/docs/implemented/README.md
+++ b/docs/implemented/README.md
@@ -45,6 +45,7 @@
 | ocd 命名 | [契约](ocd-day1-rename.md)、[结果](ocd-day1-rename-results.md) |
 | GitHub Issues #1–#3 | [请求体、Assets multipart、Cron generation 修复与验收](github-issues-1-3.md) |
 | GitHub Issue #4 | [R2 上传优化与验收](github-issue-4-r2-upload.md) |
+| 版本发布 | [0.1.2 发布说明](release-0.1.2.md) |
 
 ## 已结束调查
 

--- a/docs/implemented/release-0.1.2.md
+++ b/docs/implemented/release-0.1.2.md
@@ -1,0 +1,76 @@
+# open-compute 0.1.2
+
+0.1.2 is the first release with a complete day-to-day operator workflow for a single-machine open-compute installation. You can now initialize an instance, run it as an OS service, inspect it, open its Dashboard, upgrade the installed binary, and uninstall it without assembling those steps by hand.
+
+This release is intended for individual operators and small teams running one `ocd` process and its supervised `workerd` child on one machine.
+
+## What's new
+
+- `ocd setup` creates a configuration, protected token files, an instance registry entry, and a managed service. Use `ocd setup --yes` to accept the recommended defaults.
+- `ocd instances`, `start`, `stop`, `restart`, `status`, `logs`, and `instance remove` provide a consistent lifecycle for named local instances. Explicit selectors fail instead of silently choosing the wrong instance.
+- systemd and launchd integration installs and controls the instance service, then waits for both the local control socket and HTTP readiness check.
+- `ocd dashboard` creates a one-time local login URL. The browser exchanges it for a short-lived session instead of storing the long-lived admin token.
+- Install receipts, release checks, `ocd upgrade`, and `ocd uninstall` now cover the binary lifecycle. Upgrade verifies the release manifest and checksums, replaces only a binary owned by an open-compute receipt, and restarts only instances that were running before the upgrade.
+
+## Fixed
+
+- Instance control sockets no longer inherit an arbitrarily long macOS `TMPDIR`. When `XDG_RUNTIME_DIR` is unavailable, open-compute uses the bounded, user-specific `/tmp/open-compute-<uid>` directory. This fixes `ocd start` and setup failures caused by macOS Unix-socket path limits.
+- Database migrations shipped in a release are now immutable. Future schema changes must add a migration instead of editing an already released migration.
+
+## Before you upgrade
+
+- No data reset or configuration rewrite is required for 0.1.2.
+- 0.1.1 does not include `ocd upgrade`. Stop its managed service, install the 0.1.2 binary, and start the service again. Installations created by `scripts/install.sh` in 0.1.2 can use `ocd upgrade` for later releases.
+- `ocd uninstall` and `ocd instance remove` preserve configuration, secrets, and workload data. Removing that retained data is a separate, explicit operator action.
+- open-compute is pre-1.0. A future release may announce a breaking persisted-data change, but this release does not introduce one.
+
+After replacement, verify the installation with:
+
+```console
+ocd --version
+ocd config check
+ocd doctor
+```
+
+## Install or upgrade
+
+For a new installation, download and review the installer, then pin this release explicitly:
+
+```console
+curl -fsSL -o install.sh https://raw.githubusercontent.com/elliothux/open-compute/v0.1.2/scripts/install.sh
+OPEN_COMPUTE_RELEASE_TAG=v0.1.2 sh install.sh
+ocd setup --yes
+```
+
+The installer downloads from GitHub Releases, verifies `release.json` and `SHA256SUMS`, and refuses to overwrite a binary it does not own. It does not create configuration, data, credentials, or a service; `ocd setup` performs that step.
+
+For an existing manual or 0.1.1 installation, follow the [install and first-start runbook](https://github.com/elliothux/open-compute/blob/v0.1.2/docs/references/runbooks/install-and-first-start.md) and verify the downloaded binary against `SHA256SUMS` before replacing it.
+
+## Downloads
+
+| Host | Asset |
+| --- | --- |
+| macOS on Apple silicon | `ocd-v0.1.2-darwin-arm64` |
+| Linux on ARM64 | `ocd-v0.1.2-linux-arm64` |
+| Linux on x86-64 | `ocd-v0.1.2-linux-x64` |
+
+The release also includes `release.json` and `SHA256SUMS`. The executable embeds the pinned `v1.20260905.0-open-compute-p1.b3e1a278` runtime (`workerd 2026-09-05`); no separate runtime download is needed at startup.
+
+Windows and Intel macOS do not have qualified 0.1.2 binaries.
+
+## Security
+
+There are no published security advisories specific to 0.1.2. The new Dashboard login flow reduces exposure of the long-lived admin token, and binary upgrades fail closed on manifest, checksum, ownership, or version mismatches.
+
+## Known limitations
+
+- Interactive setup currently provisions local object storage. Configure S3-compatible storage directly in TOML when required.
+- The release qualification covers the packaged executable and service-generation behavior, not every host distribution or local systemd/launchd policy.
+- Code signing and macOS notarization are not included in 0.1.2.
+- Hosted Cloudflare differential testing, broad third-party application qualification, and long-running soak tests are separate from this release qualification.
+
+## Verification
+
+Release revision [`ff57e5bbadf0c83b65eb51d399192c472a729163`](https://github.com/elliothux/open-compute/commit/ff57e5bbadf0c83b65eb51d399192c472a729163) passed the Linux and macOS release workflow, including Rust 1.98 compatibility, linting, at least 90% Rust line coverage, workspace Gates, the controlled Linux egress fixture, native single-executable packaging, and post-upload checksum verification.
+
+[Full changelog](https://github.com/elliothux/open-compute/compare/v0.1.1...v0.1.2) · [Release workflow](https://github.com/elliothux/open-compute/actions/runs/34189528035) · [Operator experience design](https://github.com/elliothux/open-compute/blob/v0.1.2/docs/implemented/p11-ocd-operator-experience.md)

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -49,6 +49,9 @@ concurrency group，取消过期运行；汇总 job `ci` 是 `release` 分支的
 5. tag 版本等于根 `Cargo.toml` 的 `[workspace.package].version`；
 6. checkout 干净；
 7. release merge commit 对应的 main source commit 已通过 `main` push 的 `ci.yml` pre-check。
+8. `docs/implemented/release-X.Y.Z.md` 存在且是已提交的普通文件，至少包含 1000 bytes，并完整包含
+   What's new、Fixed、Before you upgrade、Install or upgrade、Downloads、Security、Known limitations 和
+   Verification 八个章节；不得保留 TODO、TBD 或 PLACEHOLDER。
 
 校验通过后，release workflow 才执行 Linux/macOS 静态检查、90% Rust 行覆盖率、完整单轮
 最终 workspace Gate（coverage 成功后执行），以及 Linux 受控 egress fixture。三个原生 runner 在身份校验后立即并行使用正式
@@ -60,7 +63,8 @@ workerd lock 打包自己的 `ocd`，并以 `OPEN_COMPUTE_TEST_OCD` 跑单文件
 
 只读 `assemble` job 只接受三个精确命名的二进制和对应 package report；它重新核对版本、revision、workerd pin、
 lock SHA-256、文件大小与文件 SHA-256，然后生成 `release.json` 和 `SHA256SUMS`。工作流的默认权限
-是只读，只有 `release` environment 中的最后一个 job 获得 `contents: write`。该 job 先创建 Draft
+是只读，只有 `release` environment 中的最后一个 job 获得 `contents: write`。该 job 只使用随 tag 提交并通过上述结构
+校验的版本说明，不使用 GitHub 自动生成的 PR 标题列表。它先创建 Draft
 GitHub Release，上传五个公开 assets，再全部下载回来逐字节比较并执行 `sha256sum --check`；全部通过
 后才把 Draft 变成正式 latest release。任一目标或回读校验失败时，不会出现部分公开 release。
 
@@ -88,12 +92,17 @@ vinext/Next.js 端到端或 hosted Cloudflare differential。其冻结摘要和�
    workerd，先运行 `bun run build`，再用宿主对应的 `OPEN_COMPUTE_TEST_WORKERD` 执行
    `./test/coverage.sh --jobs 2`；90% Rust 行覆盖率和其中的单轮 workspace Gate 都必须通过。保存失败
    证据，不自动重试；这次本地 coverage 是发版前的单轮拦截，不替代 tag workflow 的独立 coverage。
-5. 提交版本变更到 `main`，等待 main 的轻量 `ci` 通过。main CI 只做 build、快速 JS/Python、fmt、
+5. 新建 `docs/implemented/release-X.Y.Z.md` 并加入 `docs/implemented/README.md`。写法参考成熟自托管项目的
+   operator-first release notes：开头用一段话说明这版解决什么问题、适合谁；随后按 What's new 和 Fixed 归纳用户可感知的变化；
+   Before you upgrade 必须明确数据/配置兼容性、是否需要停机或人工动作，即使答案是“无”；Install or upgrade 给出可直接执行的
+   版本固定命令；Downloads 列出支持平台和精确资产名；Security 明确安全公告或“无已知公告”；Known limitations 只列会影响部署决策的
+   现实边界；Verification 只能陈述这个 revision 实际完成的资格。最后附完整 diff 链接，PR/commit 列表只能作为补充，不能替代上述内容。
+6. 提交版本变更与 release notes 到 `main`，等待 main 的轻量 `ci` 通过。main CI 只做 build、快速 JS/Python、fmt、
    workspace check、metadata 和边界检查；clippy、no-default-features、coverage、完整 workspace
    Gate、三个正式平台打包和发布验证由 tag 触发的 release workflow 负责；
-6. 以 `main` 为 head、`release` 为 base 创建并合并一个 version PR。`release` 受保护，不能直接
+7. 以 `main` 为 head、`release` 为 base 创建并合并一个 version PR。`release` 受保护，不能直接
    推送，也不能通过按版本创建临时分支绕过 PR；
-7. 确认 PR 合并产生的精确 `release` commit 已包含通过的 main pre-check，再在干净的本地 `release`
+8. 确认 PR 合并产生的精确 `release` commit 已包含通过的 main pre-check，再在干净的本地 `release`
    上创建 annotated tag。release 分支不再重复运行同一套轻量 pre-check。
 
 不要让 GitHub Actions 自动决定版本、修改文件、创建 tag 或把任意 branch HEAD 发布出去。版本是一次

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "307c0c65004e3e939202f1808af37821a572f8c0ef8c75c40024b1e45fcb1094",
+  "openComputeRevision": "b040b31a56bd4606d4ef2f55e61ff565b96ef6d140a31c1a53cdab423314aac9",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "5f92b595764892c166b36e61a81ef0b5313178554edefbb0b49a01dad7efb303",
   "workerd": {


### PR DESCRIPTION
## Summary

- add the rewritten operator-focused notes for v0.1.2
- require checked-in release notes with upgrade, download, security, limitation, and verification details
- publish those curated notes instead of GitHub generated PR lists

## Validation

- `git diff --check`
- `bun test/conformance/check.ts --case baseline-identity`
- `./test/gate.py p3-contract` (5.04s)
- main CI: https://github.com/elliothux/open-compute/actions/runs/34194171948