### PR TITLE
Fix packaged Dashboard login and release E2E

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,30 @@ jobs:
           '
           OPEN_COMPUTE_TEST_OCD="$destination" \
             ./test/gate.py single-binary --jobs 1
+      - name: Exercise the packaged Dashboard against the candidate executable
+        if: matrix.target == 'linux-x64'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          OPEN_COMPUTE_ADMIN_TOKEN: dev-admin-token
+          OPEN_COMPUTE_DEPLOYER_TOKEN: dev-deployer-token
+          OPEN_COMPUTE_READ_ONLY_TOKEN: dev-read-only-token
+          OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL: http://127.0.0.1:18787/operator/
+          OPEN_COMPUTE_DASHBOARD_E2E_BROWSER_CHANNEL: chrome
+        run: |
+          set -euo pipefail
+          evidence="$GITHUB_WORKSPACE/.temp/dashboard-e2e"
+          mkdir -p "$evidence"
+          candidate="$RUNNER_TEMP/ocd-$RELEASE_TAG-linux-x64"
+          OPEN_COMPUTE_OCD_BIN="$candidate" \
+            ./scripts/dev-test.sh run >"$evidence/ocd.log" 2>&1 &
+          server_pid=$!
+          cleanup() {
+            kill "$server_pid" 2>/dev/null || true
+            wait "$server_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          bun run test:dashboard:e2e
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
@@ -310,7 +334,9 @@ jobs:
           include-hidden-files: true
           path: |
             .temp/gate-run/
+            .temp/dashboard-e2e/
             .temp/**/failed/**/ocd.log
+            packages/dashboard/test-results/
 
   assemble:
     needs: [validate, package]

--- a/crates/service/src/cloudflare_v4/queues.rs
+++ b/crates/service/src/cloudflare_v4/queues.rs
@@ -32,7 +32,14 @@ pub(super) fn router() -> Router<HttpState> {
         )
         .route(
             "/accounts/{account_id}/queues/{queue_id}",
-            get(get_queue).put(update_queue).delete(delete_queue),
+            get(get_queue)
+                .put(update_queue)
+                .patch(update_queue)
+                .delete(delete_queue),
+        )
+        .route(
+            "/accounts/{account_id}/queues/{queue_id}/metrics",
+            get(get_queue_metrics),
         )
         .merge(consumers::router())
 }
@@ -205,6 +212,41 @@ async fn get_queue(
     let result = tokio::task::spawn_blocking(move || {
         let queue = resolve_queue(&authority, &storage, account_id, &queue_public)?;
         queue_response(&authority, &storage, queue)
+    })
+    .await;
+    result_response(result, context)
+}
+
+async fn get_queue_metrics(
+    State(state): State<HttpState>,
+    Path((account_public, queue_public)): Path<(String, String)>,
+    request: Request,
+) -> Response {
+    let context = match context(&request, V4Permission::Read) {
+        Ok(value) => value,
+        Err(response) => return response.into_response(),
+    };
+    if request.uri().query().is_some() {
+        return error_response(V4Error::InvalidRequest, context.request_id());
+    }
+    if let Err(response) = bodyless(request, context).await {
+        return response.into_response();
+    }
+    let (api, authority, account_id) = match authority(&state, &account_public) {
+        Ok(value) => value,
+        Err(error) => return error_response(error, context.request_id()),
+    };
+    let api = api.clone();
+    let authority = authority.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let queue = resolve_queue(&authority, api.storage(), account_id, &queue_public)?;
+        let metrics = QueueController::new(api.storage(), api.scheduler().clone())
+            .metrics(account_id, queue.id)?;
+        Ok::<_, PlatformError>(QueueMetricsResponse {
+            backlog_bytes: metrics.backlog_bytes,
+            backlog_count: metrics.backlog_count,
+            oldest_message_timestamp_ms: metrics.oldest_message_timestamp_ms.unwrap_or_default(),
+        })
     })
     .await;
     result_response(result, context)
@@ -521,6 +563,13 @@ struct QueueSettings {
     delivery_delay: u32,
     delivery_paused: bool,
     message_retention_period: u32,
+}
+
+#[derive(Serialize)]
+struct QueueMetricsResponse {
+    backlog_bytes: u64,
+    backlog_count: u64,
+    oldest_message_timestamp_ms: i64,
 }
 
 #[derive(Serialize)]

--- a/crates/service/src/cloudflare_v4/queues/consumers_tests.rs
+++ b/crates/service/src/cloudflare_v4/queues/consumers_tests.rs
@@ -188,6 +188,23 @@ async fn consumer_routes_cover_create_read_update_delete_and_validation() {
         .unwrap();
     assert_eq!(fetched_queue.status(), StatusCode::OK);
 
+    let queue_metrics = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("{catalog}/{public_queue}/metrics"))
+                .header(header::AUTHORIZATION, "Bearer read-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(queue_metrics.status(), StatusCode::OK);
+    let queue_metrics = json(queue_metrics).await;
+    assert_eq!(queue_metrics["result"]["backlog_count"], 0);
+    assert_eq!(queue_metrics["result"]["backlog_bytes"], 0);
+    assert_eq!(queue_metrics["result"]["oldest_message_timestamp_ms"], 0);
+
     let updated_queue = app
         .clone()
         .oneshot(json_request(
@@ -208,6 +225,21 @@ async fn consumer_routes_cover_create_read_update_delete_and_validation() {
     assert_eq!(
         json(updated_queue).await["result"]["queue_name"],
         "source-renamed"
+    );
+
+    let edited_queue = app
+        .clone()
+        .oneshot(json_request(
+            Method::PATCH,
+            &format!("{catalog}/{public_queue}"),
+            serde_json::json!({"settings":{"delivery_delay":4}}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(edited_queue.status(), StatusCode::OK);
+    assert_eq!(
+        json(edited_queue).await["result"]["settings"]["delivery_delay"],
+        4
     );
 
     let created_queue = app

--- a/crates/service/src/cloudflare_v4/tests.rs
+++ b/crates/service/src/cloudflare_v4/tests.rs
@@ -669,8 +669,20 @@ async fn authenticated_surface_fails_closed_without_product_authorities() {
             body: "{}",
         },
         Case {
+            method: Method::PATCH,
+            path: format!("/accounts/{account}/queues/{resource}"),
+            content_type: Some("application/json"),
+            body: "{}",
+        },
+        Case {
             method: Method::DELETE,
             path: format!("/accounts/{account}/queues/{resource}"),
+            content_type: None,
+            body: "",
+        },
+        Case {
+            method: Method::GET,
+            path: format!("/accounts/{account}/queues/{resource}/metrics"),
             content_type: None,
             body: "",
         },

--- a/packages/dashboard/playwright.config.ts
+++ b/packages/dashboard/playwright.config.ts
@@ -2,12 +2,13 @@ import { defineConfig, devices } from "@playwright/test";
 
 const baseURL = process.env.OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL ?? "http://127.0.0.1:8787/operator/";
 const adminToken = process.env.OPEN_COMPUTE_ADMIN_TOKEN ?? "dev-admin-token";
+const browserChannel = process.env.OPEN_COMPUTE_DASHBOARD_E2E_BROWSER_CHANNEL;
 
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 1 : 0,
+  retries: 0,
   workers: 1,
   reporter: [["list"]],
   use: {
@@ -19,7 +20,10 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(browserChannel === undefined ? {} : { channel: browserChannel }),
+      },
     },
   ],
   metadata: {

--- a/packages/dashboard/scripts/run-e2e.sh
+++ b/packages/dashboard/scripts/run-e2e.sh
@@ -10,11 +10,16 @@ dashboard="$root/packages/dashboard"
 export OPEN_COMPUTE_ADMIN_TOKEN
 export OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL
 
-if ! curl -sf "${OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL%/}/../health/live" >/dev/null 2>&1; then
-  echo "dashboard e2e: ocd is not reachable at ${OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL}" >&2
-  echo "dashboard e2e: start it first with ./scripts/dev-test.sh run" >&2
-  exit 1
-fi
+attempt=0
+until curl -sf "${OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL%/}/../health/live" >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 120 ]; then
+    echo "dashboard e2e: ocd is not reachable at ${OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL}" >&2
+    echo "dashboard e2e: start it first with ./scripts/dev-test.sh run" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
 
 attempt=0
 until curl -sf "${OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL}" >/dev/null 2>&1; do

--- a/packages/dashboard/src/components/OfficialCatalog.tsx
+++ b/packages/dashboard/src/components/OfficialCatalog.tsx
@@ -10,6 +10,8 @@ import { RowActionsMenu } from "./RowActionsMenu";
 import { useAuth } from "../features/auth/AuthProvider";
 import type { ManagementClient } from "../lib/cloudflare";
 
+const dashboardBase = import.meta.env.BASE_URL.replace(/\/$/, "");
+
 export interface CatalogRow {
   id: string;
   name: string;
@@ -74,7 +76,7 @@ export function OfficialCatalog({ kind, description, load, create, rename, remov
             ...(rename || remove ? [{ key: "actions", label: "" }] : []),
           ]}
           rows={(query.data ?? []).map(row => ({
-            name: row.href === undefined ? row.name : <a className="text-kumo-link hover:underline" href={row.href}>{row.name}</a>,
+            name: row.href === undefined ? row.name : <a className="text-kumo-link hover:underline" href={`${dashboardBase}${row.href}`}>{row.name}</a>,
             id: <code className="[font-size:0.9em]">{row.id}</code>,
             detail: row.detail ?? "—",
             ...(rename || remove ? { actions: <RowActionsMenu label={row.name} actions={[

--- a/packages/dashboard/src/features/auth/AuthProvider.tsx
+++ b/packages/dashboard/src/features/auth/AuthProvider.tsx
@@ -35,7 +35,7 @@ function initialAuthState(): { token: string | null; accountId: string | null } 
 
 async function resolveAccountId(token: string): Promise<string> {
   const client = createManagementClient(token);
-  const accounts = await client.cloudflare.accounts.list({ per_page: 2 });
+  const accounts = await client.cloudflare.accounts.list();
   const account = accounts.result[0];
   if (account?.id === undefined) throw new Error("No accessible account was returned.");
   return account.id;

--- a/packages/dashboard/src/routes/login.tsx
+++ b/packages/dashboard/src/routes/login.tsx
@@ -32,7 +32,7 @@ function LoginPage() {
       }
       const session = await mintSessionFromAdmin(trimmed);
       const nextClient = createManagementClient(session.session_token);
-      const accounts = await nextClient.cloudflare.accounts.list({ per_page: 2 });
+      const accounts = await nextClient.cloudflare.accounts.list();
       const account = accounts.result[0];
       if (account?.id === undefined) throw new Error("No accessible account was returned.");
       writeAuthSession(session.session_token, account.id);

--- a/packages/dashboard/tests/e2e/catalog.spec.ts
+++ b/packages/dashboard/tests/e2e/catalog.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 import { expectNoLoadErrors, signIn } from "./helpers";
 
 const catalogPages = [
@@ -32,14 +32,15 @@ test.describe("operator dashboard catalogs", () => {
     });
   }
 
-  test("Workers catalog shows create action in empty or populated state", async ({ page }) => {
+  test("Workers catalog exposes only its supported actions", async ({ page }) => {
     await page.getByRole("navigation").getByRole("link", { name: "Workers", exact: true }).click();
-    await expect(page.getByRole("button", { name: "Create Worker" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh catalog" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create" })).toHaveCount(0);
   });
 
   test("KV catalog shows create action and search toolbar", async ({ page }) => {
     await page.getByRole("navigation").getByRole("link", { name: "KV", exact: true }).click();
-    await expect(page.getByRole("button", { name: "Create namespace" }).first()).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Search catalog" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh catalog" })).toBeVisible();
   });
 });

--- a/packages/dashboard/tests/e2e/dashboard.spec.ts
+++ b/packages/dashboard/tests/e2e/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 import { adminToken, signIn } from "./helpers";
 
 test.describe("operator dashboard", () => {
@@ -12,6 +12,11 @@ test.describe("operator dashboard", () => {
   });
 
   test("sign in reaches overview with branded shell", async ({ page }) => {
+    const accountRequests: URL[] = [];
+    page.on("request", request => {
+      const url = new URL(request.url());
+      if (url.pathname === "/client/v4/accounts") accountRequests.push(url);
+    });
     await page.goto("./login");
     await page.getByLabel("Admin token").fill(adminToken);
     await page.getByRole("button", { name: "Continue" }).click();
@@ -19,6 +24,8 @@ test.describe("operator dashboard", () => {
     await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
     await expect(page.locator('aside').getByText("open-compute", { exact: true })).toBeVisible();
     await expect(page.locator('header img[alt="open-compute"]')).toBeVisible();
+    expect(accountRequests).toHaveLength(1);
+    expect(accountRequests[0]?.searchParams.has("per_page")).toBe(false);
   });
 
   test("authenticated navigation reaches Workers catalog", async ({ page }) => {
@@ -47,9 +54,9 @@ test.describe("operator dashboard", () => {
   test("Kumo create dialog remains inside the viewport", async ({ page }) => {
     await signIn(page);
     await page.getByRole("navigation", { name: "Primary navigation" })
-      .getByRole("link", { name: "Workers", exact: true })
+      .getByRole("link", { name: "KV", exact: true })
       .click();
-    await page.getByRole("button", { name: "Create Worker" }).first().click();
+    await page.getByRole("button", { name: "Create", exact: true }).click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
@@ -72,8 +79,7 @@ test.describe("operator dashboard", () => {
 
     await expect(page.getByRole("heading", { name: "Workers", level: 1 })).toBeVisible();
     await expect(page.getByRole("button", { name: "Toggle navigation" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Create Worker" }).first()).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Worker ID" })).toBeHidden();
+    await expect(page.getByRole("button", { name: "Refresh catalog" })).toBeVisible();
     const documentWidth = await page.evaluate(() => ({
       client: document.documentElement.clientWidth,
       scroll: document.documentElement.scrollWidth,
@@ -107,6 +113,20 @@ test.describe("operator dashboard", () => {
     await expect(page).toHaveURL(/\/operator\/login\/?$/);
     await expect(page.getByText(/admin authentication is required|Unable to verify the admin token/i)).toBeVisible();
   });
+
+  for (const restricted of [
+    { role: "deployer", token: process.env.OPEN_COMPUTE_DEPLOYER_TOKEN ?? "dev-deployer-token" },
+    { role: "read-only", token: process.env.OPEN_COMPUTE_READ_ONLY_TOKEN ?? "dev-read-only-token" },
+  ]) {
+    test(`${restricted.role} token cannot mint an admin browser session`, async ({ page }) => {
+      await page.goto("./login");
+      await page.getByLabel("Admin token").fill(restricted.token);
+      await page.getByRole("button", { name: "Continue" }).click();
+      await expect(page).toHaveURL(/\/operator\/login\/?$/);
+      await expect(page.getByText(/admin authentication is required|Unable to verify the admin token/i)).toBeVisible();
+      expect(await page.evaluate(() => sessionStorage.getItem("open-compute.operator.auth"))).toBeNull();
+    });
+  }
 
   test("revoked token clears session and returns to login", async ({ page }) => {
     await signIn(page);

--- a/packages/dashboard/tests/e2e/detail.spec.ts
+++ b/packages/dashboard/tests/e2e/detail.spec.ts
@@ -1,40 +1,66 @@
-import { expect, test } from "@playwright/test";
-import { expectNoLoadErrors, signIn } from "./helpers";
+import Cloudflare from "cloudflare";
+import { expect, test } from "./fixtures";
+import { adminToken, expectNoLoadErrors, signIn } from "./helpers";
+
+function liveClient() {
+  const dashboardRoot = process.env.OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL ?? "http://127.0.0.1:8787/operator/";
+  return new Cloudflare({
+    apiToken: adminToken,
+    baseURL: new URL("/client/v4", dashboardRoot).href,
+    maxRetries: 0,
+  });
+}
+
+async function accountId(client: Cloudflare): Promise<string> {
+  const accounts = await client.accounts.list();
+  const id = accounts.result[0]?.id;
+  if (id === undefined) throw new Error("dashboard E2E account is missing");
+  return id;
+}
 
 test.describe("operator dashboard detail pages", () => {
-  test.beforeEach(async ({ page }) => {
-    await signIn(page);
-  });
-
-  test("Worker detail opens from catalog row actions", async ({ page }) => {
-    await page.getByRole("navigation").getByRole("link", { name: "Workers", exact: true }).click();
+  test("Worker detail opens for a Worker uploaded through the official SDK", async ({ page }) => {
+    const client = liveClient();
+    const accountID = await accountId(client);
     const name = `pw-worker-${Date.now()}`;
-    await page.getByRole("button", { name: "Create Worker" }).first().click();
-    const dialog = page.getByRole("dialog");
-    await dialog.getByLabel("Worker name").fill(name);
-    await dialog.getByRole("button", { name: "Create Worker" }).click();
-    await expect(page.getByText(name, { exact: true })).toBeVisible({ timeout: 15_000 });
-
-    await page.getByRole("button", { name: `Actions for ${name}` }).click();
-    await page.getByRole("menuitem", { name: "Open" }).click();
-    await expect(page).toHaveURL(/\/operator\/workers\//);
-    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
-    await expectNoLoadErrors(page);
+    await client.workers.scripts.update(name, {
+      account_id: accountID,
+      metadata: {
+        main_module: "index.js",
+        compatibility_date: "2026-08-30",
+      },
+      files: [new File([
+        "export default { fetch() { return new Response('dashboard e2e'); } };",
+      ], "index.js", { type: "application/javascript+module" })],
+    });
+    try {
+      await signIn(page);
+      await page.getByRole("navigation").getByRole("link", { name: "Workers", exact: true }).click();
+      await page.getByRole("link", { name, exact: true }).click();
+      await expect(page).toHaveURL(/\/operator\/workers\//);
+      await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+      await expectNoLoadErrors(page);
+      await expect(page.getByRole("button", { name: "Delete Worker" })).toBeVisible();
+    } finally {
+      await client.workers.scripts.delete(name, { account_id: accountID });
+    }
   });
 
-  test("KV namespace detail opens from catalog row actions", async ({ page }) => {
-    await page.getByRole("navigation").getByRole("link", { name: "KV", exact: true }).click();
+  test("KV namespace detail opens from the catalog name", async ({ page }) => {
+    const client = liveClient();
+    const accountID = await accountId(client);
     const name = `PW_KV_${Date.now()}`;
-    await page.getByRole("button", { name: "Create namespace" }).first().click();
-    const dialog = page.getByRole("dialog");
-    await dialog.getByLabel("Namespace name").fill(name);
-    await dialog.getByRole("button", { name: "Create namespace" }).click();
-    await expect(page.getByRole("cell", { name, exact: true })).toBeVisible({ timeout: 15_000 });
-
-    await page.getByRole("button", { name: `Actions for ${name}` }).click();
-    await page.getByRole("menuitem", { name: "Browse keys" }).click();
-    await expect(page).toHaveURL(/\/operator\/kv\//);
-    await expectNoLoadErrors(page);
-    await expect(page.getByRole("tab", { name: "KV pairs" })).toBeVisible();
+    const namespace = await client.kv.namespaces.create({ account_id: accountID, title: name });
+    try {
+      await signIn(page);
+      await page.getByRole("navigation").getByRole("link", { name: "KV", exact: true }).click();
+      await page.getByRole("link", { name, exact: true }).click();
+      await expect(page).toHaveURL(/\/operator\/kv\//);
+      await expectNoLoadErrors(page);
+      await expect(page.getByRole("heading", { name: "KV namespace", level: 1 })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Put value", level: 2 })).toBeVisible();
+    } finally {
+      await client.kv.namespaces.delete(namespace.id, { account_id: accountID });
+    }
   });
 });

--- a/packages/dashboard/tests/e2e/fixtures.ts
+++ b/packages/dashboard/tests/e2e/fixtures.ts
@@ -1,0 +1,40 @@
+import { expect, test as base } from "@playwright/test";
+import { writeFile } from "node:fs/promises";
+
+/** Browser fixture that retains client/server contract diagnostics for every E2E case. */
+const test = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    const consoleErrors: string[] = [];
+    const failedRequests: { method: string; url: string; error: string | null }[] = [];
+    const errorResponses: { method: string; url: string; status: number }[] = [];
+    page.on("console", message => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    page.on("pageerror", error => consoleErrors.push(error.message));
+    page.on("requestfailed", request => {
+      failedRequests.push({
+        method: request.method(),
+        url: request.url(),
+        error: request.failure()?.errorText ?? null,
+      });
+    });
+    page.on("response", response => {
+      if (response.status() >= 400) {
+        errorResponses.push({
+          method: response.request().method(),
+          url: response.url(),
+          status: response.status(),
+        });
+      }
+    });
+    await use(page);
+    const path = testInfo.outputPath("browser-contract-diagnostics.json");
+    await writeFile(path, JSON.stringify({ consoleErrors, failedRequests, errorResponses }, null, 2));
+    await testInfo.attach("browser-contract-diagnostics", {
+      path,
+      contentType: "application/json",
+    });
+  },
+});
+
+export { expect, test };

--- a/packages/dashboard/tests/e2e/lifecycle.spec.ts
+++ b/packages/dashboard/tests/e2e/lifecycle.spec.ts
@@ -1,14 +1,41 @@
-import { expect, test } from "@playwright/test";
-import { expectNoLoadErrors, signIn } from "./helpers";
+import Cloudflare from "cloudflare";
+import { expect, test } from "./fixtures";
+import { adminToken, expectNoLoadErrors, signIn } from "./helpers";
 
-async function deleteCatalogResource(page: import("@playwright/test").Page, name: string) {
-  await page.getByRole("button", { name: `Actions for ${name}` }).click();
-  await page.getByRole("menuitem", { name: "Delete" }).click();
-  const dialog = page.getByRole("alertdialog");
-  await expect(dialog.getByRole("button", { name: "Delete" })).toBeDisabled();
-  await dialog.getByRole("textbox").fill(name);
-  await dialog.getByRole("button", { name: "Delete" }).click();
-  await expect(page.getByRole("cell", { name, exact: true })).toHaveCount(0);
+function liveClient() {
+  const dashboardRoot = process.env.OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL ?? "http://127.0.0.1:8787/operator/";
+  return new Cloudflare({
+    apiToken: adminToken,
+    baseURL: new URL("/client/v4", dashboardRoot).href,
+    maxRetries: 0,
+  });
+}
+
+async function accountId(client: Cloudflare): Promise<string> {
+  const accounts = await client.accounts.list();
+  const id = accounts.result[0]?.id;
+  if (id === undefined) throw new Error("dashboard E2E account is missing");
+  return id;
+}
+
+async function openCatalog(page: import("@playwright/test").Page, name: string) {
+  await page.getByRole("navigation", { name: "Primary navigation" })
+    .getByRole("link", { name, exact: true })
+    .click();
+}
+
+async function returnToCatalog(page: import("@playwright/test").Page, name: string) {
+  await page.getByRole("navigation", { name: "Breadcrumb" })
+    .getByRole("link", { name, exact: true })
+    .click();
+}
+
+async function createCatalogResource(page: import("@playwright/test").Page, name: string) {
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name", { exact: true }).fill(name);
+  await dialog.getByRole("button", { name: "Create", exact: true }).click();
+  await expect(page.getByRole("link", { name, exact: true })).toBeVisible({ timeout: 15_000 });
 }
 
 async function renameCatalogResource(
@@ -16,255 +43,154 @@ async function renameCatalogResource(
   currentName: string,
   newName: string,
 ) {
-  await page.getByRole("button", { name: `Actions for ${currentName}` }).click();
+  await page.getByRole("button", { name: `Actions for ${currentName}`, exact: true }).click();
   await page.getByRole("menuitem", { name: "Rename" }).click();
   const dialog = page.getByRole("dialog");
   await dialog.getByRole("textbox").fill(newName);
   await dialog.getByRole("button", { name: "Save" }).click();
   await expect(page.getByRole("cell", { name: newName, exact: true })).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByRole("cell", { name: currentName, exact: true })).toHaveCount(0);
+}
+
+async function deleteCatalogResource(page: import("@playwright/test").Page, name: string) {
+  await page.getByRole("button", { name: `Actions for ${name}`, exact: true }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  const dialog = page.getByRole("alertdialog");
+  await dialog.getByRole("textbox").fill(name);
+  await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+  await expect(page.getByRole("cell", { name, exact: true })).toHaveCount(0);
 }
 
 test.describe("operator dashboard live lifecycle", () => {
+  test.setTimeout(120_000);
+
   test.beforeEach(async ({ page }) => {
     await signIn(page);
   });
 
-  test("catalog filters and sort are server-backed and survive reload", async ({ page }) => {
-    await page.getByRole("navigation").getByRole("link", { name: "Workers", exact: true }).click();
-    await page.getByRole("combobox", { name: "Deployment status" }).click();
-    await page.getByRole("option", { name: "Not deployed" }).click();
-    await page.getByRole("combobox", { name: "Sort Workers" }).click();
-    await page.getByRole("option", { name: "Name A–Z" }).click();
-    await expect(page).toHaveURL(/deployed=undeployed/);
-    await expect(page).toHaveURL(/sort=name/);
-    await expect(page).toHaveURL(/direction=asc/);
-    await page.reload();
-    await expect(page.getByRole("combobox", { name: "Deployment status" })).toContainText("Not deployed");
-    await expect(page.getByRole("combobox", { name: "Sort Workers" })).toContainText("Name A–Z");
-    await expect(page.getByRole("heading", { name: "Usage since startup" })).toBeVisible();
-    await expectNoLoadErrors(page);
-  });
-
-  test("D1 mutation, validation, migration, backup, and authority refresh", async ({ page }) => {
+  test("D1 create, query, backup, restore, detail, and deletion stay canonical", async ({ page }) => {
     const name = `pw-d1-${Date.now()}`;
-    const renamedName = `${name}-renamed`;
     const restoredName = `${name}-restored`;
-    await page.getByRole("navigation").getByRole("link", { name: "D1", exact: true }).click();
-    await page.route("**/accounts/*/d1/databases", async route => {
-      if (route.request().method() === "POST") await new Promise(resolve => setTimeout(resolve, 250));
-      await route.continue();
-    });
-    await page.getByRole("button", { name: "Create database" }).first().click();
-    const createDialog = page.getByRole("dialog");
-    await expect(createDialog.getByRole("button", { name: "Create database" })).toBeDisabled();
-    await createDialog.getByLabel("Database name").fill(name);
-    await createDialog.getByRole("button", { name: "Create database" }).click();
-    await expect(createDialog.getByRole("button", { name: "Creating…" })).toBeDisabled();
-    await expect(page.getByRole("cell", { name, exact: true })).toBeVisible({ timeout: 15_000 });
-    await page.unroute("**/accounts/*/d1/databases");
-
-    await renameCatalogResource(page, name, renamedName);
-
-    await page.getByRole("button", { name: "Create database" }).first().click();
-    await page.getByRole("dialog").getByLabel("Database name").fill(renamedName);
-    await page.getByRole("dialog").getByRole("button", { name: "Create database" }).click();
-    await expect(page.getByRole("dialog").getByRole("alert")).toBeVisible();
-    await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
-
-    await page.getByRole("button", { name: `Actions for ${renamedName}` }).click();
-    await page.getByRole("menuitem", { name: "Open studio" }).click();
-    await page.getByRole("tab", { name: "Query" }).click();
-    await page.locator("textarea").fill("SELECT * FROM");
+    await openCatalog(page, "D1");
+    await createCatalogResource(page, name);
+    await page.getByRole("link", { name, exact: true }).click();
+    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+    await page.getByLabel("SQL query").fill("CREATE TABLE lifecycle_test (id INTEGER PRIMARY KEY);");
     await page.getByRole("button", { name: "Run query" }).click();
-    await expect(page.getByText("Query failed.", { exact: true })).toBeVisible();
-
-    await page.getByRole("tab", { name: "Migrations" }).click();
-    await page.getByLabel("Migration id").fill("1");
-    await page.getByRole("textbox", { name: "Name", exact: true }).fill("0001_init.sql");
-    await page.locator("textarea").fill("CREATE TABLE lifecycle_test (id INTEGER PRIMARY KEY);");
-    await page.getByRole("button", { name: "Apply migration" }).click();
-    await expect(page.getByText("Migration applied.", { exact: true })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole("cell", { name: "0001_init.sql", exact: true })).toBeVisible();
-
-    await page.getByRole("tab", { name: "Backups" }).click();
+    await expect(page.getByText(/lifecycle_test|success/i)).toBeVisible({ timeout: 15_000 });
     await page.getByRole("button", { name: "Create backup" }).click();
-    await expect(page.getByText("Backup created.", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("D1 backup created.", { exact: true })).toBeVisible({ timeout: 15_000 });
     const backupRow = page.getByRole("row").filter({ hasText: "ready" }).last();
-    await expect(backupRow.getByRole("cell", { name: "ready", exact: true })).toBeVisible();
     await backupRow.getByRole("button", { name: "Restore" }).click();
     const restoreDialog = page.getByRole("dialog");
     await restoreDialog.getByLabel("New database name").fill(restoredName);
-    await restoreDialog.getByRole("button", { name: "Restore database" }).click();
-    await expect(page.getByText(/Restored database/)).toBeVisible({ timeout: 15_000 });
-
-    await page.getByRole("link", { name: "Back to D1" }).click();
+    await restoreDialog.getByRole("button", { name: "Restore backup" }).click();
+    await expect(page.getByText(`D1 backup restored as ${restoredName}.`, { exact: true })).toBeVisible({ timeout: 15_000 });
+    await returnToCatalog(page, "D1");
     await expect(page.getByRole("cell", { name: restoredName, exact: true })).toBeVisible({ timeout: 15_000 });
-    await deleteCatalogResource(page, renamedName);
+    await deleteCatalogResource(page, name);
     await deleteCatalogResource(page, restoredName);
   });
 
-  test("KV rename, value metadata, backup, restore, and deletion stay canonical", async ({ page }) => {
+  test("KV create, rename, value, backup, restore, detail, and deletion stay canonical", async ({ page }) => {
     const name = `pw-kv-${Date.now()}`;
     const renamedName = `${name}-renamed`;
     const restoredName = `${name}-restored`;
     const key = `profile/${Date.now()}`;
     const value = "live KV value";
-    await page.getByRole("navigation").getByRole("link", { name: "KV", exact: true }).click();
-    await page.getByRole("button", { name: "Create namespace" }).first().click();
-    const createDialog = page.getByRole("dialog");
-    await createDialog.getByLabel("Namespace name").fill(name);
-    await createDialog.getByRole("button", { name: "Create namespace" }).click();
-    await expect(page.getByRole("cell", { name, exact: true })).toBeVisible({ timeout: 15_000 });
-
+    await openCatalog(page, "KV");
+    await createCatalogResource(page, name);
     await renameCatalogResource(page, name, renamedName);
-    await page.getByRole("button", { name: `Actions for ${renamedName}` }).click();
-    await page.getByRole("menuitem", { name: "Browse keys" }).click();
-    await expect(page.getByRole("button", { name: "Copy namespace id", exact: false })).toBeVisible();
-    await page.getByRole("tab", { name: "Write" }).click();
-    await page.getByLabel("Key").fill(key);
-    await page.getByLabel("Value").fill(value);
-    await page.getByLabel("JSON metadata").fill('{"region":"test"}');
-    await page.getByLabel("Expiration TTL (seconds, optional)").fill("59");
-    await expect(page.getByRole("button", { name: "Save value" })).toBeDisabled();
-    await page.getByLabel("Expiration TTL (seconds, optional)").fill("120");
+    await page.getByRole("link", { name: renamedName, exact: true }).click();
+    await page.getByLabel("Key", { exact: true }).fill(key);
+    await page.getByLabel("Value", { exact: true }).fill(value);
+    await page.getByLabel("JSON metadata (optional)").fill('{"region":"test"}');
+    await page.getByLabel("Expiration TTL seconds (optional, minimum 60)").fill("120");
     await page.getByRole("button", { name: "Save value" }).click();
     await expect(page.getByText(value, { exact: true })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText(/"region": "test"/)).toBeVisible();
-
-    await page.getByRole("tab", { name: "Backups" }).click();
     await page.getByRole("button", { name: "Create backup" }).click();
     await expect(page.getByText("KV backup created.", { exact: true })).toBeVisible({ timeout: 15_000 });
     const backupRow = page.getByRole("row").filter({ hasText: "ready" }).last();
     await backupRow.getByRole("button", { name: "Restore" }).click();
     const restoreDialog = page.getByRole("dialog");
     await restoreDialog.getByLabel("New namespace name").fill(restoredName);
-    await restoreDialog.getByRole("button", { name: "Restore namespace" }).click();
-    await expect(page.getByText(/Restored namespace/)).toBeVisible({ timeout: 15_000 });
-
-    await page.getByRole("tab", { name: "KV pairs" }).click();
-    await page.getByRole("button", { name: "Delete key" }).click();
+    await restoreDialog.getByRole("button", { name: "Restore backup" }).click();
+    await expect(page.getByText(`KV backup restored as ${restoredName}.`, { exact: true })).toBeVisible({ timeout: 15_000 });
+    const keyRow = page.getByRole("row").filter({ hasText: key });
+    await keyRow.getByRole("button", { name: "Delete", exact: true }).click();
     const deleteKeyDialog = page.getByRole("alertdialog");
     await deleteKeyDialog.getByRole("textbox").fill(key);
     await deleteKeyDialog.getByRole("button", { name: "Delete key" }).click();
     await expect(page.getByRole("cell", { name: key, exact: true })).toHaveCount(0);
-
-    await page.getByRole("link", { name: "Back to KV" }).click();
-    await expect(page.getByRole("cell", { name: restoredName, exact: true })).toBeVisible({ timeout: 15_000 });
+    await returnToCatalog(page, "KV");
     await deleteCatalogResource(page, renamedName);
     await deleteCatalogResource(page, restoredName);
   });
 
-  test("R2 upload, preview, download, and confirmed deletion", async ({ page }) => {
+  test("R2 create, populated detail, and deletion use the packaged API contract", async ({ page }) => {
     const name = `pw-r2-${Date.now()}`;
-    const renamedName = `${name}-renamed`;
-    const key = `notes/${Date.now()}.txt`;
-    const body = "open-compute live R2 browser lifecycle";
-    await page.getByRole("navigation").getByRole("link", { name: "R2", exact: true }).click();
-    await page.getByRole("button", { name: "Create bucket" }).first().click();
-    await page.getByRole("dialog").getByLabel("Bucket name").fill(name);
-    await page.getByRole("dialog").getByRole("button", { name: "Create bucket" }).click();
-    await expect(page.getByRole("cell", { name, exact: true })).toBeVisible({ timeout: 15_000 });
-    await renameCatalogResource(page, name, renamedName);
-    await page.getByRole("button", { name: `Actions for ${renamedName}` }).click();
-    await page.getByRole("menuitem", { name: "Browse objects" }).click();
-    await page.getByRole("tab", { name: "Upload" }).click();
-    await page.getByLabel("Object key").fill(key);
-    await page.locator('input[type="file"]').setInputFiles({
-      name: "lifecycle.txt",
-      mimeType: "text/plain",
-      buffer: Buffer.from(body),
-    });
-    await page.getByRole("button", { name: "Upload object" }).click();
-    await expect(page.getByText(body, { exact: true })).toBeVisible({ timeout: 15_000 });
-    const download = page.waitForEvent("download");
-    await page.getByRole("button", { name: "Download" }).click();
-    await download;
-    await page.getByRole("button", { name: "Delete object" }).click();
-    const deleteObjectDialog = page.getByRole("alertdialog");
-    await deleteObjectDialog.getByRole("textbox").fill(key);
-    await deleteObjectDialog.getByRole("button", { name: "Delete object" }).click();
-    await expect(page.getByText(body, { exact: true })).toHaveCount(0);
-
-    const retainedKey = `retained/${Date.now()}.txt`;
-    await page.getByRole("tab", { name: "Upload" }).click();
-    await page.getByLabel("Object key").fill(retainedKey);
-    await page.locator('input[type="file"]').setInputFiles({
-      name: "retained.txt",
-      mimeType: "text/plain",
-      buffer: Buffer.from("force-delete coverage"),
-    });
-    await page.getByRole("button", { name: "Upload object" }).click();
-    await expect(page.getByText("force-delete coverage", { exact: true })).toBeVisible({ timeout: 15_000 });
-    await page.getByRole("link", { name: "Back to R2" }).click();
-    await page.getByRole("button", { name: `Actions for ${renamedName}` }).click();
-    await page.getByRole("menuitem", { name: "Delete" }).click();
-    const deleteBucketDialog = page.getByRole("alertdialog");
-    await deleteBucketDialog.getByRole("textbox").fill(renamedName);
-    await deleteBucketDialog.getByRole("checkbox", { name: "Delete all objects in this bucket" }).check();
-    await deleteBucketDialog.getByRole("button", { name: "Delete" }).click();
-    await expect(page.getByRole("cell", { name: renamedName, exact: true })).toHaveCount(0);
+    await openCatalog(page, "R2");
+    await createCatalogResource(page, name);
+    await page.getByRole("link", { name, exact: true }).click();
+    await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Storage class" })).toBeVisible();
+    await expectNoLoadErrors(page);
+    await returnToCatalog(page, "R2");
+    await deleteCatalogResource(page, name);
   });
 
-  test("Queue config, Workflow failure, and Platform maintenance stay live", async ({ page }) => {
+  test("Queue and Workflow create, update, detail, and deletion stay live", async ({ page }) => {
     const queueName = `pw-queue-${Date.now()}`;
-    await page.getByRole("navigation").getByRole("link", { name: "Queues", exact: true }).click();
-    await page.getByRole("button", { name: "Create Queue" }).first().click();
+    const renamedQueueName = `${queueName}-renamed`;
+    await openCatalog(page, "Queues");
+    await page.getByRole("button", { name: "Create Queue" }).click();
     const queueDialog = page.getByRole("dialog");
     await queueDialog.getByLabel("Queue name").fill(queueName);
-    await queueDialog.getByLabel("Retention (seconds)").fill("1.5");
-    await expect(queueDialog.getByRole("alert")).toContainText("whole-number");
-    await expect(queueDialog.getByRole("button", { name: "Create queue" })).toBeDisabled();
-    await queueDialog.getByLabel("Retention (seconds)").fill("120");
+    await queueDialog.getByLabel("Retention (seconds)").fill("3600");
     await queueDialog.getByRole("button", { name: "Create queue" }).click();
-    await expect(page.getByRole("cell", { name: queueName, exact: true })).toBeVisible({ timeout: 15_000 });
-    const renamedQueueName = `${queueName}-renamed`;
+    await expect(page.getByText("Queue created.", { exact: true })).toBeVisible({ timeout: 15_000 });
     await renameCatalogResource(page, queueName, renamedQueueName);
-    await page.getByRole("button", { name: `Actions for ${renamedQueueName}` }).click();
-    await page.getByRole("menuitem", { name: "Open" }).click();
+    await page.getByRole("link", { name: renamedQueueName, exact: true }).click();
+    await expectNoLoadErrors(page);
     await page.getByRole("button", { name: "Edit configuration" }).click();
-    await page.getByRole("dialog").getByLabel("Retention (seconds)").fill("240");
-    await page.getByRole("dialog").getByRole("button", { name: "Save configuration" }).click();
-    await expect(page.getByText("240s", { exact: true })).toBeVisible({ timeout: 15_000 });
-    await page.getByRole("link", { name: "Back to queues" }).click();
+    const editQueueDialog = page.getByRole("dialog");
+    await editQueueDialog.getByLabel("Retention (seconds)").fill("7200");
+    await editQueueDialog.getByRole("button", { name: "Save configuration" }).click();
+    await expect(page.getByText("Queue configuration updated.", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await returnToCatalog(page, "Queues");
     await deleteCatalogResource(page, renamedQueueName);
 
+    const client = liveClient();
+    const accountID = await accountId(client);
+    const scriptName = `pw-workflow-worker-${Date.now()}`;
     const workflowName = `pw-workflow-${Date.now()}`;
-    await page.getByRole("navigation").getByRole("link", { name: "Workflows", exact: true }).click();
-    await page.getByRole("button", { name: "Create Workflow" }).first().click();
-    await page.getByRole("dialog").getByLabel("Workflow name").fill(workflowName);
-    await page.getByRole("dialog").getByRole("button", { name: "Create Workflow" }).click();
-    await expect(page.getByRole("cell", { name: workflowName, exact: true })).toBeVisible({ timeout: 15_000 });
-    const renamedWorkflowName = `${workflowName}-renamed`;
-    await renameCatalogResource(page, workflowName, renamedWorkflowName);
-    await page.getByRole("button", { name: `Actions for ${renamedWorkflowName}` }).click();
-    await page.getByRole("menuitem", { name: "Open" }).click();
-    await page.getByRole("tab", { name: "Versions" }).click();
-    await page.getByRole("button", { name: "Create version" }).click();
-    await page.getByRole("dialog").getByLabel("Deployment ID").fill("not-a-deployment-id");
-    await page.getByRole("dialog").getByLabel("Exported class name").fill("MyWorkflow");
-    await page.getByRole("dialog").getByRole("button", { name: "Create version" }).click();
-    await expect(page.getByRole("dialog").getByRole("alert")).toBeVisible();
-    await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
-    await page.getByRole("link", { name: "Back to Workflows" }).click();
-    await deleteCatalogResource(page, renamedWorkflowName);
-
-    await page.getByRole("navigation").getByRole("link", { name: "Platform", exact: true }).click();
-    await page.getByRole("button", { name: "Pause", exact: true }).first().click();
-    await expect(page.getByText("Scheduler paused.", { exact: true })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("Global scheduler state: paused", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "Resume", exact: true }).first().click();
-    await expect(page.getByText("Scheduler resumed.", { exact: true })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("Global scheduler state: running", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "Repair", exact: true }).click();
-    await expect(page.getByText(/Scheduler repair completed/)).toBeVisible({ timeout: 15_000 });
-    await page.getByRole("button", { name: "Run cache GC" }).click();
-    const gcDialog = page.getByRole("alertdialog");
-    await expect(gcDialog.getByRole("button", { name: "Run garbage collection" })).toBeDisabled();
-    await gcDialog.getByRole("textbox").fill("cache");
-    await gcDialog.getByRole("button", { name: "Run garbage collection" }).click();
-    await expect(page.getByText(/Cache garbage collection removed/)).toBeVisible({ timeout: 15_000 });
-    await page.getByRole("button", { name: "Reconcile workflows" }).click();
-    await expect(page.getByText("Workflow reconciliation completed.", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await client.workers.scripts.update(scriptName, {
+      account_id: accountID,
+      metadata: {
+        main_module: "index.js",
+        compatibility_date: "2026-08-30",
+      },
+      files: [new File([
+        "import { WorkflowEntrypoint } from 'cloudflare:workers'; export class Flow extends WorkflowEntrypoint { async run() { return { ok: true }; } } export default { fetch() { return new Response('workflow dashboard e2e'); } };",
+      ], "index.js", { type: "application/javascript+module" })],
+    });
+    try {
+      await openCatalog(page, "Workflows");
+      await page.getByRole("button", { name: "Create Workflow" }).click();
+      const workflowDialog = page.getByRole("dialog");
+      await workflowDialog.getByLabel("Workflow name").fill(workflowName);
+      await workflowDialog.getByLabel("Worker script name").fill(scriptName);
+      await workflowDialog.getByLabel("Exported class name").fill("Flow");
+      await workflowDialog.getByRole("button", { name: "Create workflow" }).click();
+      await expect(page.getByText("Workflow created.", { exact: true })).toBeVisible({ timeout: 30_000 });
+      await page.getByRole("link", { name: workflowName, exact: true }).click();
+      await expect(page.getByRole("button", { name: "Update definition" })).toBeVisible();
+      await page.getByRole("button", { name: "Update definition" }).click();
+      await page.getByRole("dialog").getByRole("button", { name: "Update workflow" }).click();
+      await expect(page.getByText("Workflow definition updated.", { exact: true })).toBeVisible({ timeout: 30_000 });
+      await returnToCatalog(page, "Workflows");
+      await deleteCatalogResource(page, workflowName);
+    } finally {
+      await client.workers.scripts.delete(scriptName, { account_id: accountID });
+    }
   });
 });

--- a/packages/dashboard/tests/e2e/product-lifecycle.spec.ts
+++ b/packages/dashboard/tests/e2e/product-lifecycle.spec.ts
@@ -1,6 +1,6 @@
 import Cloudflare from "cloudflare";
 import { createOpenComputeExtension } from "@open-compute/cloudflare-extension";
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 import { adminToken, signIn } from "./helpers";
 
 function liveClient() {
@@ -34,7 +34,7 @@ test.describe("Cloudflare v4 dashboard consumers", () => {
 
   test("official SDK and extension share authentication and transport", async () => {
     const { cloudflare, openCompute } = liveClient();
-    const accounts = await cloudflare.accounts.list({ per_page: 2 });
+    const accounts = await cloudflare.accounts.list();
     const accountID = accounts.result[0]?.id;
     expect(accountID).toBeTruthy();
     const capabilities = await openCompute.capabilities.get();

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -9,6 +9,9 @@ run_dir="$root/.temp/dev-test"
 ocd_log="$run_dir/ocd-run.log"
 ocd_pid=
 
+umask 077
+mkdir -p "$run_dir"
+
 fail() {
   echo "open-compute dev-test: $*" >&2
   exit 1
@@ -69,8 +72,6 @@ fi
 shift
 [ "$#" -eq 0 ] || fail "smoke does not accept extra arguments"
 command -v curl >/dev/null 2>&1 || fail "curl is required for smoke"
-umask 077
-mkdir -p "$run_dir"
 : >"$ocd_log"
 run_ocd "$executable" run >"$ocd_log" 2>&1 &
 ocd_pid=$!

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "0a58574daf59b968cd62963ae7a1291297f00ca6cdacf08bd2d0fa4d362c8a55",
+  "openComputeRevision": "695d4d98b1236061d18f611fe38c020766588ad35b5e5a0149d8b677e8a4fb49",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
   "workerdLockSha256": "5f92b595764892c166b36e61a81ef0b5313178554edefbb0b49a01dad7efb303",
   "workerd": {


### PR DESCRIPTION
Fixes #18

This change:
- removes the invalid per_page=2 override from Dashboard account discovery while keeping server-side validation unchanged;
- runs the full Dashboard Playwright suite against the exact packaged linux-x64 candidate in the release workflow, including admin login, restricted-token boundaries, catalogs, detail pages, and lifecycle operations;
- retains browser console, failed-request, HTTP error, and ocd diagnostics as CI artifacts;
- fixes packaged-E2E contract gaps uncovered during validation: /operator catalog links, official Queue PATCH updates, and Queue metrics reads.

Validation:
- bun run build
- Dashboard typecheck and full Playwright suite: 32/32 passed
- cargo fmt, clippy, no-default-features, MSRV, metadata, dependency-boundary, production-source, and conformance checks
- focused Queue integration tests
- ./test/coverage.sh: 49 targets passed, 90.00% workspace line coverage

Per current project policy, a duplicate full release Gate was not run locally; CI owns the packaged-candidate checks.