### PR TITLE
Fix runtime capabilities in Durable Objects and Workflows

### DIFF
--- a/crates/service/tests/p3_services_events.rs
+++ b/crates/service/tests/p3_services_events.rs
@@ -21,8 +21,10 @@ use open_compute_storage::{
 use open_compute_workers::{
     BundleLimits, CanonicalBundle, CreateResourceOutcome, CreateResourceRequest,
     CreateVersionOutcome, CreateVersionRequest, DurableObjectResourceDriver, ModuleInput,
-    ModuleType, ResourceController, ResourcePins, RuntimeValidator, VersionBindingInput,
-    VersionContent, VersionController, VersionServiceInput,
+    ModuleType, ResourceController, ResourcePins, RuntimeValidator, VersionAiInput,
+    VersionBindingInput, VersionCacheInput, VersionCachePolicyInput, VersionContent,
+    VersionController, VersionImagesInput, VersionRuntimeFeatures, VersionServiceInput,
+    VersionVersionMetadataInput,
 };
 use p3_services_support::Harness;
 use std::collections::BTreeMap;
@@ -46,6 +48,28 @@ export default class Target extends WorkerEntrypoint {
 const EVENTS: &str = r#"
 import { DurableObject, WorkflowEntrypoint } from "cloudflare:workers";
 
+async function verifyContextCapabilities(env, ctx, source) {
+  if (ctx.cache !== undefined) throw new Error(`${source} automatic cache must be disabled`);
+  if (typeof env.IMAGES.info !== "function") throw new Error(`${source} Images binding missing`);
+  if (typeof env.AI.toMarkdown !== "function") throw new Error(`${source} AI binding missing`);
+  if (typeof env.VERSION.id !== "string" || env.VERSION.tag !== "event-contexts"
+      || typeof env.VERSION.timestamp !== "string") {
+    throw new Error(`${source} Version Metadata binding missing`);
+  }
+  const key = `https://cache-context.invalid/${source}`;
+  await caches.default.put(key, new Response(`default:${source}`, {
+    headers: { "cache-control": "max-age=60" },
+  }));
+  const cached = await caches.default.match(key);
+  if (await cached?.text() !== `default:${source}`) throw new Error(`${source} default cache failed`);
+  const named = await caches.open(`context-${source}`);
+  await named.put(key, new Response(`named:${source}`, {
+    headers: { "cache-control": "max-age=60" },
+  }));
+  const namedCached = await named.match(key);
+  if (await namedCached?.text() !== `named:${source}`) throw new Error(`${source} named cache failed`);
+}
+
 async function socketPing(target, source) {
   const socket = target.connect(`${source}.invalid:1`, { allowHalfOpen: true });
   await socket.opened;
@@ -61,11 +85,17 @@ async function socketPing(target, source) {
 }
 
 export class ObjectEvent extends DurableObject {
-  async fetch() { return new Response(await socketPing(this.env.TARGET, "do")); }
+  async fetch() {
+    await verifyContextCapabilities(this.env, this.ctx, "do");
+    return new Response(await socketPing(this.env.TARGET, "do"));
+  }
 }
 
 export class Flow extends WorkflowEntrypoint {
-  async run() { return socketPing(this.env.TARGET, "workflow"); }
+  async run() {
+    await verifyContextCapabilities(this.env, this.ctx, "workflow");
+    return socketPing(this.env.TARGET, "workflow");
+  }
 }
 
 export default {
@@ -161,6 +191,7 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
         )]),
         2,
     );
+    event_request.runtime_features = context_runtime_features();
     event_request.crons = vec!["* * * * *".to_owned()];
     let event_version = deploy(&controller, event_request).await;
     let dispatch_target = dispatch_target(account, events.id, &event_version, None);
@@ -272,6 +303,29 @@ async fn p3_service_calls_from_queue_cron_do_and_workflow_event_sources() {
     }
     wait_service_drain(&harness, "workflow").await;
     harness.stop().await;
+}
+
+fn context_runtime_features() -> VersionRuntimeFeatures {
+    VersionRuntimeFeatures {
+        cache: VersionCacheInput {
+            default: VersionCachePolicyInput {
+                enabled: true,
+                cross_version_cache: false,
+            },
+            entrypoints: BTreeMap::new(),
+        },
+        images: Some(VersionImagesInput {
+            binding: "IMAGES".to_owned(),
+        }),
+        ai: Some(VersionAiInput {
+            binding: "AI".to_owned(),
+        }),
+        version_metadata: Some(VersionVersionMetadataInput {
+            binding: "VERSION".to_owned(),
+            tag: Some("event-contexts".to_owned()),
+        }),
+        ..VersionRuntimeFeatures::default()
+    }
 }
 
 fn create_namespace(

--- a/crates/service/tests/p3_services_support/mod.rs
+++ b/crates/service/tests/p3_services_support/mod.rs
@@ -4,8 +4,8 @@ use open_compute_artifacts::{
     ArtifactCache, ArtifactStore, MapEnv, MockS3, ObjectBackend, resolve_s3_credentials_with,
 };
 use open_compute_core::{
-    CacheConfig, DataConfig, DurableObjectsConfig, PlatformConfig, Redactor, RuntimeConfig,
-    StartupId, SystemClock,
+    CacheConfig, DataConfig, DurableObjectsConfig, PlatformConfig, Redactor, ResponseCacheConfig,
+    RuntimeConfig, StartupId, SystemClock,
 };
 use open_compute_runtime::{
     DirectoryServicePath, ExternalServiceAddress, GenerationAuthRegistry, OsJitter,
@@ -13,6 +13,7 @@ use open_compute_runtime::{
     WorkerdSupervisorOptions, verify_runtime_binary,
 };
 use open_compute_service::asset_backend::AssetBindingService;
+use open_compute_service::cache_backend::CacheBindingService;
 use open_compute_service::runtime_bridge::{
     WorkerdTransport, bind_runtime_source, serve_runtime_source,
 };
@@ -57,7 +58,7 @@ impl Harness {
         );
         let mock = MockS3::spawn("open-compute").await;
         let artifacts = artifact_store(&mock);
-        let cache = Arc::new(
+        let artifact_cache = Arc::new(
             ArtifactCache::open(
                 storage.data_dir().artifact_cache_dir(),
                 CacheConfig::default(),
@@ -98,10 +99,19 @@ impl Harness {
             let auth = binding_auth.clone();
             let pins = version_pins.clone();
             let services = service_invocations.clone();
+            let response_cache = Arc::new(
+                CacheBindingService::new(
+                    storage.clone(),
+                    artifacts.clone(),
+                    artifact_cache.clone(),
+                    ResponseCacheConfig::default(),
+                )
+                .unwrap(),
+            );
             let asset_service = Arc::new(AssetBindingService::new(
                 storage.clone(),
                 artifacts.clone(),
-                cache,
+                artifact_cache,
                 pins.clone(),
             ));
             async move {
@@ -123,7 +133,7 @@ impl Harness {
                     None,
                     asset_service,
                     services,
-                    None,
+                    Some(response_cache),
                     None,
                     async move {
                         let _ = binding_shutdown.changed().await;

--- a/docs/references/cloudflare-compatibility.md
+++ b/docs/references/cloudflare-compatibility.md
@@ -45,12 +45,12 @@ authority 差异；它不代表缺方法、占位返回或半截实现。
 | KV | `supported_with_deviation` | 52 | 单键/批量 overload、metadata、stream、list、`cacheStatus`、错误时序和恢复均闭环 | `OC-KV-001` |
 | R2 | `supported_with_deviation` | 110 | object/body/list/options、全部 checksum、SSE-C、storage class、条件写、multipart、opaque physical key、持久 intent/reconcile 和 restart 均闭环；single/part/multipart ETag 公式及 lowercase-hex `ssecKeyMd5` 与官方 Worker API 一致 | `OC-R2-001` |
 | D1 | `supported_with_deviation` | 36 | database/session/prepared statement/result/meta、opaque bookmark、原子 batch/exec、错误转换和非 alpha `dump()` 拒绝均闭环 | `OC-D1-001` |
-| Durable Objects | `supported_with_deviation` | 115 | namespace/ID/stub/native RPC facet、state、sync KV/SQL、transaction、alarm、hibernation、output gate 和显式 connect tunnel 均闭环；112 个成员使用 `OC-DO-001`，3 个 connect 成员使用 TCP/limit deviation | `OC-DO-001`、`OC-WKR-TCP-001`、`OC-WKR-LIMIT-001` |
+| Durable Objects | `supported_with_deviation` | 115 | namespace/ID/stub/native RPC facet、state、sync KV/SQL、transaction、alarm、hibernation、output gate、显式 connect tunnel，以及 Cache API/声明 binding 的对象内可用性均闭环；112 个成员使用 `OC-DO-001`，3 个 connect 成员使用 TCP/limit deviation | `OC-DO-001`、`OC-WKR-TCP-001`、`OC-WKR-LIMIT-001` |
 | DO Alarms | `supported` | 7 | get/set/delete、handler、retry/restart authority 均闭环 | — |
 | Queues | `supported_with_deviation` | 63 | producer、consumer、`v8`、metrics、delay、ack/retry、output gate、at-least-once recovery 均闭环 | `OC-QUEUE-001` |
 | Cron | `supported_with_deviation` | 26 | scheduled handler、`noRetry()`、Workflow schedules、projection/recovery 均闭环 | `OC-CRON-001` |
-| Workflows | `supported_with_deviation` | 72 | binding/instance/batch/delete、structured clone、step config、parallel DAG、event、restart-from-step、rollback、DO output gate 均闭环 | `OC-WORKFLOW-001` |
-| Cache API | `supported_with_deviation` | 14 | `Cache`/`CacheStorage`、vary/range/condition、purge、restart 和自动 cache 协作均闭环 | `OC-CACHE-001`、`OC-CACHE-002` |
+| Workflows | `supported_with_deviation` | 72 | binding/instance/batch/delete、structured clone、step config、parallel DAG、event、restart-from-step、rollback、DO output gate，以及 Cache API/声明 binding 的 Workflow 内可用性均闭环 | `OC-WORKFLOW-001` |
+| Cache API | `supported_with_deviation` | 14 | `Cache`/`CacheStorage`、vary/range/condition、purge、restart、自动 cache 协作及 Worker/DO/Workflow execution-context matrix 均闭环 | `OC-CACHE-001`、`OC-CACHE-002` |
 | Version Metadata | `supported` | 3 | `id`、`tag`、`timestamp` 由 immutable deployment authority 注入 | — |
 | WebSocket hibernation | `supported` | 19 | accept/tags/get、auto-response、serialize/deserialize attachment、reconstruction 和 restart 均闭环 | — |
 | Vectorize | `supported_with_deviation` | 27 | stable post-beta `Vectorize` 的 7 个方法、异步持久 mutation、三种公开 score/order、namespace、indexed metadata filter/projection、restart recovery 与全 stable response surface 均闭环；beta `VectorizeIndex` 不在当前 Day1 合同 | `OC-VECTORIZE-001` |
@@ -81,6 +81,20 @@ deviation 规范文本、官方来源和边界见 [`p1-deviations.md`](p1-deviat
 backend 和 workerd 内部 listener 仍仅监听 loopback。
 
 ## 关键实现说明
+
+### Worker、Durable Object 与 Workflow capability matrix
+
+自动 Workers Caching 只包裹普通 Worker 的 HTTP `fetch` entrypoint；Durable Object 调用和 Workflow
+执行不进入该自动缓存层，`ctx.cache` 也不向这两类执行暴露。全局 `caches.default` / `caches.open()` 是与其
+独立的编程式 Cache API，因此在 Worker、Durable Object 和 Workflow 三种环境中均可用。配置在 immutable
+Version 上的 Images、当前声明子集内的 AI、Version Metadata 及其它产品 binding 同样按原名注入 DO 的
+`this.env` 与 Workflow 的 `this.env`。官方依据是 [Workers Caching invocation limitations](https://developers.cloudflare.com/workers/cache/limitations/)、
+[Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/)、[bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/)
+以及官方 Workflow 中直接使用 `this.env.AI` 的[示例](https://developers.cloudflare.com/workflows/examples/wait-for-event/)。
+
+本地真实 pinned-workerd 回归在同一 immutable Version 上验证 DO 与 Workflow 的 default/named Cache API、
+Images/AI/Version Metadata binding 可见性、Service Binding 共存，并断言两种 context 的自动 caching 仍关闭。
+Cloudflare-hosted Workflow differential 仍受下文账号权限限制；本地结果不外推成尚未执行的 hosted 证据。
 
 ### R2 上传调度与完整性
 

--- a/packages/runtime/src/durable-objects/host.ts
+++ b/packages/runtime/src/durable-objects/host.ts
@@ -385,7 +385,8 @@ export class DoHost extends DurableObject<DoHostEnv> {
       ...lockWorkerCode(this.env),
       mainModule: built.mainModule,
       modules: built.modules,
-      env: tenantEnv(snapshot, this.ctx, this.env.WORKER_LOADER_FACTORY, authority.versionId, doPolicy(this.env), true, false),
+      env: tenantEnv(snapshot, this.ctx, this.env.WORKER_LOADER_FACTORY, authority.versionId,
+        doPolicy(this.env), true, entrypoint),
       globalOutbound: tenantGlobalOutbound(this.env, false),
     };
     Object.defineProperties(code.env, {

--- a/packages/runtime/src/loader/bindings.ts
+++ b/packages/runtime/src/loader/bindings.ts
@@ -63,8 +63,7 @@ function makeModuleBinding(binding: RuntimeModuleBinding): unknown {
 
 export function tenantEnv(snapshot: RuntimeSnapshot, ctx: BindingContext,
   loaderFactory: NativeWorkerLoaderFactory, versionId: string,
-  policy: DoPolicy, durableObject = false, builtinFeatures = true,
-  currentEntrypoint = "default"): Record<string, unknown> {
+  policy: DoPolicy, durableObject = false, currentEntrypoint = "default"): Record<string, unknown> {
   const env = { ...snapshot.env };
   const [accountId, workerId] = snapshot.loaderKey.split("/");
   if (!accountId || !workerId) throw bindingError("VERSION_INVARIANT_VIOLATION");
@@ -98,54 +97,52 @@ export function tenantEnv(snapshot: RuntimeSnapshot, ctx: BindingContext,
       ...(service.entrypoint === undefined ? {} : { entrypoint: service.entrypoint }),
     }) });
   }
-  if (builtinFeatures && !durableObject) {
-    const cacheTransports: Record<string, unknown> = {};
-    const defaultCachePolicy = {
-      enabled: snapshot.cachePolicy.enabled,
-      crossVersionCache: snapshot.cachePolicy.crossVersionCache,
-    };
-    for (const [cacheEntrypoint, selected] of Object.entries({
-      default: defaultCachePolicy,
-      ...snapshot.cachePolicy.entrypoints,
-      [currentEntrypoint]: snapshot.cachePolicy.entrypoints[currentEntrypoint] ?? defaultCachePolicy,
-    })) {
-      cacheTransports[cacheEntrypoint] = ctx.exports.CacheTransport({ props: Object.freeze({
-        accountId, workerId, versionId, entrypoint: cacheEntrypoint,
-        descriptorSha256: snapshot.workerCodeSha256,
-        automaticEnabled: selected.enabled,
-        crossVersionCache: selected.crossVersionCache,
-      }) });
-    }
-    Object.defineProperty(env, "__OPEN_COMPUTE_PRIVATE_CACHE", {
-      value: Object.freeze(cacheTransports),
-      enumerable: true,
-      configurable: true,
-      writable: false,
+  const cacheTransports: Record<string, unknown> = {};
+  const defaultCachePolicy = {
+    enabled: snapshot.cachePolicy.enabled,
+    crossVersionCache: snapshot.cachePolicy.crossVersionCache,
+  };
+  for (const [cacheEntrypoint, selected] of Object.entries({
+    default: defaultCachePolicy,
+    ...snapshot.cachePolicy.entrypoints,
+    [currentEntrypoint]: snapshot.cachePolicy.entrypoints[currentEntrypoint] ?? defaultCachePolicy,
+  })) {
+    cacheTransports[cacheEntrypoint] = ctx.exports.CacheTransport({ props: Object.freeze({
+      accountId, workerId, versionId, entrypoint: cacheEntrypoint,
+      descriptorSha256: snapshot.workerCodeSha256,
+      automaticEnabled: selected.enabled,
+      crossVersionCache: selected.crossVersionCache,
+    }) });
+  }
+  Object.defineProperty(env, "__OPEN_COMPUTE_PRIVATE_CACHE", {
+    value: Object.freeze(cacheTransports),
+    enumerable: true,
+    configurable: true,
+    writable: false,
+  });
+  if (snapshot.imagesBinding) {
+    const { name, descriptorSha256 } = snapshot.imagesBinding;
+    if (Object.prototype.hasOwnProperty.call(env, name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
+    env[name] = ctx.exports.ImageTransport({ props: Object.freeze({
+      accountId, workerId, versionId, descriptorSha256,
+    }) });
+  }
+  if (snapshot.aiBinding) {
+    const { name, descriptorSha256 } = snapshot.aiBinding;
+    if (Object.prototype.hasOwnProperty.call(env, name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
+    env[name] = ctx.exports.AiTransport({ props: Object.freeze({
+      accountId, workerId, versionId, descriptorSha256,
+    }) });
+  }
+  if (snapshot.versionMetadataBinding) {
+    const metadata = snapshot.versionMetadataBinding;
+    if (Object.prototype.hasOwnProperty.call(env, metadata.name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
+    const timestamp = new Date(metadata.timestampMs).toISOString();
+    env[metadata.name] = Object.freeze({
+      id: metadata.id,
+      tag: metadata.tag ?? "",
+      timestamp,
     });
-    if (snapshot.imagesBinding) {
-      const { name, descriptorSha256 } = snapshot.imagesBinding;
-      if (Object.prototype.hasOwnProperty.call(env, name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
-      env[name] = ctx.exports.ImageTransport({ props: Object.freeze({
-        accountId, workerId, versionId, descriptorSha256,
-      }) });
-    }
-    if (snapshot.aiBinding) {
-      const { name, descriptorSha256 } = snapshot.aiBinding;
-      if (Object.prototype.hasOwnProperty.call(env, name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
-      env[name] = ctx.exports.AiTransport({ props: Object.freeze({
-        accountId, workerId, versionId, descriptorSha256,
-      }) });
-    }
-    if (snapshot.versionMetadataBinding) {
-      const metadata = snapshot.versionMetadataBinding;
-      if (Object.prototype.hasOwnProperty.call(env, metadata.name)) throw bindingError("VERSION_INVARIANT_VIOLATION");
-      const timestamp = new Date(metadata.timestampMs).toISOString();
-      env[metadata.name] = Object.freeze({
-        id: metadata.id,
-        tag: metadata.tag ?? "",
-        timestamp,
-      });
-    }
   }
   return env;
 }

--- a/packages/runtime/src/loader/host.ts
+++ b/packages/runtime/src/loader/host.ts
@@ -606,7 +606,7 @@ async function handle(request: Request, env: LoaderEnv, ctx: ExecutionContext, v
           mainModule: built.mainModule,
           modules: built.modules,
           env: validation ? {} : tenantEnv(
-            snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, true, entrypoint ?? "default",
+            snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, entrypoint ?? "default",
           ),
           globalOutbound: tenantGlobalOutbound(env, validation),
         };
@@ -738,7 +738,7 @@ async function customEventTarget(request: Request, env: LoaderEnv, ctx: Executio
         mainModule: built.mainModule,
         modules: built.modules,
         env: tenantEnv(
-          snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, true, entrypoint ?? "default",
+          snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, entrypoint ?? "default",
         ),
         globalOutbound: tenantGlobalOutbound(env, false),
       };

--- a/packages/runtime/src/loader/modules.ts
+++ b/packages/runtime/src/loader/modules.ts
@@ -108,9 +108,8 @@ export function modulesFor(snapshot: RuntimeSnapshot, validation: boolean, entry
   }
   if (has("workflow")) modules[WORKFLOW_FACADE_MODULE] = { js: workflowFacadeSource };
   if (snapshot.assetBinding) modules[ASSET_FACADE_MODULE] = { js: assetFacadeSource };
-  const cacheAvailable = !durableObject && !workflow;
-  if (cacheAvailable) modules[CACHE_FACADE_MODULE] = { js: cacheFacadeSource };
-  if (snapshot.imagesBinding && cacheAvailable) modules[IMAGES_FACADE_MODULE] = { js: imagesFacadeSource };
+  modules[CACHE_FACADE_MODULE] = { js: cacheFacadeSource };
+  if (snapshot.imagesBinding) modules[IMAGES_FACADE_MODULE] = { js: imagesFacadeSource };
   if (snapshot.aiBinding) modules[AI_FACADE_MODULE] = { js: aiFacadeSource };
   if (has("vectorize_index")) modules[VECTORIZE_FACADE_MODULE] = { js: vectorizeFacadeSource };
   if (has("ai_search_namespace") || has("ai_search_instance")) {
@@ -132,17 +131,16 @@ export function modulesFor(snapshot: RuntimeSnapshot, validation: boolean, entry
     js: generateBindingWrapper({
       mainModule: snapshot.mainModule, bindings: snapshot.bindings, services: snapshot.services,
       entrypointName, durableObject, workflow, assetBindingName: snapshot.assetBinding?.name,
-      imagesBindingName: cacheAvailable ? snapshot.imagesBinding?.name : undefined,
+      imagesBindingName: snapshot.imagesBinding?.name,
       aiBindingName: snapshot.aiBinding?.name,
       scheduledTargets: snapshot.scheduledTargets,
-      cacheAvailable,
       cacheFailOpen: snapshot.cachePolicy.failOpen,
       automaticCacheEntrypoints: entrypointName === undefined
         ? Object.entries(snapshot.cachePolicy.entrypoints)
           .filter(([, policy]) => policy.enabled)
           .map(([name]) => name)
         : [],
-      automaticCacheEnabled: !validation && cacheAvailable && (entrypointName === undefined
+      automaticCacheEnabled: !validation && !durableObject && !workflow && (entrypointName === undefined
         ? snapshot.cachePolicy.enabled
         : (snapshot.cachePolicy.entrypoints[entrypointName]?.enabled ?? snapshot.cachePolicy.enabled)),
     }),

--- a/packages/runtime/src/loader/wrappers/durable-object.ts
+++ b/packages/runtime/src/loader/wrappers/durable-object.ts
@@ -10,7 +10,7 @@ import type {
 import {
   tenantConstructor, trackExecutionContext, trustedContextExports, wrapInstance,
 } from "./runtime.js";
-import type { Environment, EnvironmentWrapper } from "./runtime.js";
+import type { CacheRuntimeFactory, Environment, EnvironmentWrapper } from "./runtime.js";
 import type { NativeHostFacets } from "../protocol.js";
 
 function nativeHostFacets(value: unknown): value is NativeHostFacets {
@@ -63,7 +63,8 @@ function tenantContext(
 }
 
 /** Keep alarm state outside tenant objects and prepare storage before construction. */
-export function wrapDurableObject(target: unknown, wrapEnv: EnvironmentWrapper, name: string) {
+export function wrapDurableObject(target: unknown, wrapEnv: EnvironmentWrapper, name: string,
+  cache?: CacheRuntimeFactory) {
   const Base = tenantConstructor(target);
   const states = new WeakMap<object, ReturnType<typeof prepareDurableObjectContext> | undefined>();
   const stateFor = (instance: object) => {
@@ -73,6 +74,7 @@ export function wrapDurableObject(target: unknown, wrapEnv: EnvironmentWrapper, 
   };
   const Wrapped = class extends Base {
     constructor(ctx: DurableObjectState, env: Environment) {
+      cache?.bind(env);
       const trustedExports = trustedContextExports(ctx);
       const wrapped = wrapEnv(env);
       const index = env.__OPEN_COMPUTE_PRIVATE_ALARM_INDEX;

--- a/packages/runtime/src/loader/wrappers/generator.ts
+++ b/packages/runtime/src/loader/wrappers/generator.ts
@@ -45,7 +45,6 @@ export interface WrapperOptions {
   assetBindingName?: string | undefined;
   imagesBindingName?: string | undefined;
   aiBindingName?: string | undefined;
-  cacheAvailable: boolean;
   automaticCacheEnabled: boolean;
   cacheFailOpen: boolean;
   automaticCacheEntrypoints?: readonly string[] | undefined;
@@ -57,7 +56,7 @@ function fromWrapper(module: string): string { return JSON.stringify(`./${module
 /** Only module wiring and validated data are generated; behavior lives in TS modules. */
 export function generateBindingWrapper(options: WrapperOptions): string {
   const { mainModule, bindings, services, entrypointName, durableObject, workflow = false,
-    assetBindingName, imagesBindingName, aiBindingName, cacheAvailable, automaticCacheEnabled,
+    assetBindingName, imagesBindingName, aiBindingName, automaticCacheEnabled,
     cacheFailOpen, automaticCacheEntrypoints = [], scheduledTargets = [] } = options;
   if (entrypointName !== undefined && !/^[A-Za-z_$][A-Za-z0-9_$]{0,127}$/.test(entrypointName)) {
     throw new Error("invalid entrypoint name");
@@ -84,9 +83,7 @@ export function generateBindingWrapper(options: WrapperOptions): string {
   }
   const main = JSON.stringify(`../${mainModule}`);
   const lines: string[] = [];
-  if (cacheAvailable) {
-    lines.push(`import { createCacheRuntime } from ${fromWrapper(CACHE_FACADE_MODULE)};`);
-  }
+  lines.push(`import { createCacheRuntime } from ${fromWrapper(CACHE_FACADE_MODULE)};`);
   lines.push(
     `import * as tenant from ${main};`, `export * from ${main};`,
     `import { createLoopbackEntrypoint } from ${fromWrapper(LOOPBACK_MODULE)};`,
@@ -127,11 +124,11 @@ export function generateBindingWrapper(options: WrapperOptions): string {
   }
   lines.push(`const wrapEnv = createEnvironment([${factories.join(",")}], ${durableObject});`);
   lines.push(`export const __OpenComputeLoopbackService = createLoopbackEntrypoint(tenant, wrapEnv, wrapEntrypoint, ${JSON.stringify([...automaticCacheEntrypoints, ...(entrypointName && entrypointName !== "default" ? [entrypointName] : [])])});`);
-  lines.push(`const cacheRuntime = ${cacheAvailable ? `createCacheRuntime(${automaticCacheEnabled}, ${cacheFailOpen}, ${JSON.stringify(entrypointName ?? "default")})` : "undefined"};`);
+  lines.push(`const cacheRuntime = createCacheRuntime(${!durableObject && !workflow && automaticCacheEnabled}, ${cacheFailOpen}, ${JSON.stringify(entrypointName ?? "default")});`);
   if (workflow) {
     lines.push(`import { createWorkflowEntrypoint } from ${fromWrapper(WORKFLOW_WRAPPER_MODULE)};`);
     lines.push(`import { runWorkflow, validateWorkflowClass } from ${fromWrapper(WORKFLOW_RUNNER_MODULE)};`);
-    lines.push(`const __OpenComputeWorkflow = createWorkflowEntrypoint(tenant[${JSON.stringify(entrypointName)}], wrapEnv, runWorkflow, validateWorkflowClass);`);
+    lines.push(`const __OpenComputeWorkflow = createWorkflowEntrypoint(tenant[${JSON.stringify(entrypointName)}], wrapEnv, runWorkflow, validateWorkflowClass, cacheRuntime);`);
     lines.push("export { __OpenComputeWorkflow };");
   } else if (entrypointName !== undefined && (durableObject || entrypointName !== "default")) {
     const factory = durableObject ? "wrapDurableObject" : "wrapEntrypoint";

--- a/packages/runtime/src/loader/wrappers/workflow.ts
+++ b/packages/runtime/src/loader/wrappers/workflow.ts
@@ -2,7 +2,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import type { WorkflowEventWire, WorkflowRunResult } from "../../workflows/execution-protocol.js";
 import {
   invokeEntrypoint, trackExecutionContext, trustedContextExports,
-  type Environment, type EnvironmentWrapper, type TrackedContext,
+  type CacheRuntimeFactory, type Environment, type EnvironmentWrapper, type TrackedContext,
 } from "./runtime.js";
 
 /** Select the matching runner/controller contract without exposing either in tenant env. */
@@ -11,12 +11,14 @@ export function createWorkflowEntrypoint<Controller>(
   wrapEnv: EnvironmentWrapper,
   run: (target: unknown, ctx: ExecutionContext, env: Environment, event: WorkflowEventWire, controller: Controller) => Promise<WorkflowRunResult>,
   validate: (target: unknown) => boolean,
+  cache?: CacheRuntimeFactory,
 ) {
   return class extends WorkerEntrypoint<Environment> {
     #tracked: TrackedContext<ExecutionContext> | undefined;
 
     validate(): boolean { return validate(target); }
     execute(event: WorkflowEventWire, controller: Controller): Promise<WorkflowRunResult> {
+      cache?.bind(this.env);
       const trustedExports = trustedContextExports(this.ctx);
       const wrapped = wrapEnv(this.env);
       const tracked = this.#tracked ??= trackExecutionContext(

--- a/packages/runtime/src/services/transport.ts
+++ b/packages/runtime/src/services/transport.ts
@@ -408,7 +408,7 @@ async function loadedServiceTarget(
         mainModule: built.mainModule,
         modules: built.modules,
         env: tenantEnv(
-          snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, true, entrypoint ?? "default",
+          snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, entrypoint ?? "default",
         ),
         globalOutbound: tenantGlobalOutbound(env, false),
       };

--- a/packages/runtime/src/workflows/host.ts
+++ b/packages/runtime/src/workflows/host.ts
@@ -55,7 +55,8 @@ export async function handleWorkflow(request: Request, env: LoaderEnv, ctx: Exec
       const code = {
         ...lockWorkerCode(env),
         mainModule: built.mainModule, modules: built.modules,
-        env: validation ? {} : tenantEnv(snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId, doPolicy(env), false, false),
+        env: validation ? {} : tenantEnv(snapshot, ctx, env.WORKER_LOADER_FACTORY, versionId,
+          doPolicy(env), false, className),
         globalOutbound: tenantGlobalOutbound(env, validation),
       };
       return code;

--- a/packages/runtime/tests/cache/bindings.test.mjs
+++ b/packages/runtime/tests/cache/bindings.test.mjs
@@ -31,7 +31,7 @@ test("tenant env creates a cache transport for the current unconfigured entrypoi
       CacheTransport({ props }) { transports.push(props); return props; },
     },
   };
-  const env = tenantEnv(snapshot, ctx, {}, "version", {}, false, true, "Named");
+  const env = tenantEnv(snapshot, ctx, {}, "version", {}, false, "Named");
   assert.deepEqual(Object.keys(env.__OPEN_COMPUTE_PRIVATE_CACHE).sort(), ["Admin", "Named", "default"]);
   assert.deepEqual(transports.map(value => [
     value.entrypoint, value.automaticEnabled, value.crossVersionCache,
@@ -60,16 +60,51 @@ test("tenant env resolves AI from the immutable version descriptor", () => {
   assert.equal(typeof env.AI.transform, "function");
 });
 
+test("DO and Workflow env keep programmatic cache and declared built-ins", () => {
+  const configured = {
+    ...snapshot,
+    imagesBinding: { name: "IMAGES", descriptorSha256: "bc".repeat(32) },
+    aiBinding: { name: "AI", descriptorSha256: "cd".repeat(32) },
+    versionMetadataBinding: {
+      name: "VERSION",
+      id: "version",
+      tag: "context-matrix",
+      timestampMs: 10,
+    },
+  };
+  for (const context of [
+    { durableObject: true, entrypoint: "Object" },
+    { durableObject: false, entrypoint: "Flow" },
+  ]) {
+    const cacheProps = [];
+    const env = tenantEnv(configured, { exports: {
+      CacheTransport({ props }) { cacheProps.push(props); return props; },
+      ImageTransport({ props }) { return { kind: "images", props }; },
+      AiTransport({ props }) { return { kind: "ai", props }; },
+    } }, {}, "version", {}, context.durableObject, context.entrypoint);
+    assert.equal(env.__OPEN_COMPUTE_PRIVATE_CACHE[context.entrypoint].entrypoint, context.entrypoint);
+    assert.equal(cacheProps.some(props => props.entrypoint === context.entrypoint), true);
+    assert.equal(env.IMAGES.kind, "images");
+    assert.equal(env.AI.kind, "ai");
+    assert.deepEqual(env.VERSION, {
+      id: "version",
+      tag: "context-matrix",
+      timestamp: "1970-01-01T00:00:00.010Z",
+    });
+  }
+});
+
 
 test("tenant env receives only native loader capabilities from verified descriptors", () => {
   const capability = Object.freeze({ load() {}, get() {} });
   const keys = [];
   const factory = { get(key) { keys.push(key); return capability; } };
   const configured = { ...snapshot, workerLoaders: [{ name: "LOADER", namespaceKey: "private-authority" }] };
-  const env = tenantEnv(configured, { exports: {} }, factory, "version", {}, false, false);
+  const ctx = { exports: { CacheTransport({ props }) { return props; } } };
+  const env = tenantEnv(configured, ctx, factory, "version", {}, false);
   assert.deepEqual(keys, ["private-authority"]);
   assert.equal(env.LOADER, capability);
-  assert.deepEqual(Object.keys(env).sort(), ["LOADER", "PUBLIC"]);
+  assert.deepEqual(Object.keys(env).sort(), ["LOADER", "PUBLIC", "__OPEN_COMPUTE_PRIVATE_CACHE"]);
   assert.throws(() => tenantEnv({ ...configured, env: { LOADER: "conflict" } },
-    { exports: {} }, factory, "version", {}, false, false), /VERSION_INVARIANT_VIOLATION/);
+    ctx, factory, "version", {}, false), /VERSION_INVARIANT_VIOLATION/);
 });

--- a/packages/runtime/tests/loader/wrappers.test.mjs
+++ b/packages/runtime/tests/loader/wrappers.test.mjs
@@ -72,6 +72,9 @@ const {
 const { completions } = await import(serviceFacade);
 const serviceScopeState = await import(serviceScope);
 const workflowFacadeState = await import(workflowFacade);
+const cacheFacade = moduleUrl(`
+  export function createCacheRuntime() { return { bind() { return undefined; } }; }
+`);
 const { createWorkflowEntrypoint } = await importRuntime("loader/wrappers/workflow.ts", {
   "cloudflare:workers": cloudflare,
   "./runtime.js": runtimeUrl,
@@ -353,6 +356,7 @@ test("Workflow entrypoints give the private controller only to the runner", asyn
     context: true,
     waitUntil(promise) { promise.catch(() => undefined); },
   };
+  const cacheEnvironments = [];
   const Entry = createWorkflowEntrypoint(target, createEnvironment([], false), async (actual, ctx, env, event, backend) => {
     assert.equal(actual, target);
     assert.equal(ctx, context);
@@ -362,7 +366,7 @@ test("Workflow entrypoints give the private controller only to the runner", asyn
     assert.deepEqual(env, { USER: "public" });
     assert.deepEqual(event, { payloadJson: "null" });
     return { outcome: "complete", outputJson: "42", finalOrdinal: 0 };
-  }, value => value === target);
+  }, value => value === target, { bind(env) { cacheEnvironments.push(env); return undefined; } });
   const entry = new Entry(context, { USER: "public", __OPEN_COMPUTE_PRIVATE_ALARM_INDEX: "hidden" });
   assert.equal(entry.ctx, context);
   assert.equal(entry.validate(), true);
@@ -372,6 +376,8 @@ test("Workflow entrypoints give the private controller only to the runner", asyn
   }
   assert.equal(serviceScopeState.scopeRuns, priorScopes + 1);
   assert.equal(completions.length, priorCompletions + 1);
+  assert.equal(cacheEnvironments.length, 1);
+  assert.equal(cacheEnvironments[0].USER, "public");
   assert.equal(scope.getStore(), undefined);
 });
 
@@ -392,9 +398,10 @@ test("Durable Object methods share the root Service scope and tracked waitUntil 
       return `${this.env.VALUE}:${this.ctx.storage}:${this.env.OBJECTS.value}:${this.privateExportsHidden}`;
     }
   }
+  const cacheEnvironments = [];
   const Wrapped = wrapDurableObject(Tenant, createEnvironment([{
     names: ["OBJECTS"], create: Capability,
-  }], true), "Object");
+  }], true), "Object", { bind(env) { cacheEnvironments.push(env); return undefined; } });
   let contextWaits = 0;
   const context = {
     get storage() {
@@ -433,6 +440,8 @@ test("Durable Object methods share the root Service scope and tracked waitUntil 
   assert.equal(serviceScopeState.scopeRuns, priorScopes + 1);
   assert.equal(completions.length, priorCompletions + 1);
   assert.equal(contextWaits, 2);
+  assert.equal(cacheEnvironments.length, 1);
+  assert.equal(cacheEnvironments[0].VALUE, "ok");
 });
 
 test("Durable Object WebSocket responses hand ownership to native hibernation", async () => {
@@ -475,12 +484,16 @@ test("Durable Object WebSocket responses hand ownership to native hibernation", 
 
 test("generated modules only wire imports and configuration into the checked runtime", async () => {
   const tenant = moduleUrl(`export const named = 42; export default { fetch(_request, env) { return env.GREETING; } };`);
-  const code = generator.generateBindingWrapper({ mainModule: "index.js", bindings: [], services: [], durableObject: false });
+  const code = generator.generateBindingWrapper({
+    mainModule: "index.js", bindings: [], services: [], durableObject: false,
+    automaticCacheEnabled: false, cacheFailOpen: true,
+  });
   assert.deepEqual(parseSync("entry.js", code, { sourceType: "module" }).errors, []);
   assert.doesNotMatch(code, /\b(class|function|for|if)\b/);
   const mapped = code.replaceAll('"../index.js"', JSON.stringify(tenant))
     .replaceAll('"./loader/wrappers/runtime.js"', JSON.stringify(runtimeUrl))
-    .replaceAll('"./loader/wrappers/loopback.js"', JSON.stringify(loopbackUrl));
+    .replaceAll('"./loader/wrappers/loopback.js"', JSON.stringify(loopbackUrl))
+    .replaceAll('"./cache/facade.js"', JSON.stringify(cacheFacade));
   const entry = await import(moduleUrl(mapped));
   assert.equal(entry.named, 42);
   assert.equal(entry.default.fetch({}, { GREETING: "hello" }, {
@@ -488,9 +501,15 @@ test("generated modules only wire imports and configuration into the checked run
   }), "hello");
   assert.equal(await validationHandler(entry, "default").fetch().text(), "open-compute-validation-v1");
   assert.throws(() => validationHandler(entry, "missing"), /missing entrypoint/);
-  assert.equal(generator.generateBindingWrapper({ mainModule: "index.js", bindings: [], services: [], entrypointName: "default", durableObject: false }), code);
+  assert.equal(generator.generateBindingWrapper({
+    mainModule: "index.js", bindings: [], services: [], entrypointName: "default",
+    durableObject: false, automaticCacheEnabled: false, cacheFailOpen: true,
+  }), code);
   for (const name of ['bad";throw 1;', "nested.name", "A".repeat(129)]) {
-    assert.throws(() => generator.generateBindingWrapper({ mainModule: "index.js", bindings: [], services: [], entrypointName: name, durableObject: false }), /invalid entrypoint/);
+    assert.throws(() => generator.generateBindingWrapper({
+      mainModule: "index.js", bindings: [], services: [], entrypointName: name,
+      durableObject: false, automaticCacheEnabled: false, cacheFailOpen: true,
+    }), /invalid entrypoint/);
   }
 });
 
@@ -506,7 +525,8 @@ test("all binding and entrypoint combinations produce valid import-only bridges"
     const code = generator.generateBindingWrapper({
       mainModule: "src/index.js", bindings,
       services: [{ name: "CATALOG" }], assetBindingName: "ASSETS", imagesBindingName: "IMAGES",
-      aiBindingName: "AI", durableObject: false, ...options,
+      aiBindingName: "AI", durableObject: false, automaticCacheEnabled: true,
+      cacheFailOpen: true, ...options,
     });
     assert.deepEqual(parseSync("entry.js", code, { sourceType: "module" }).errors, []);
     assert.match(code, /WorkflowBinding/);
@@ -517,6 +537,7 @@ test("all binding and entrypoint combinations produce valid import-only bridges"
     assert.match(code, /VectorizeBinding/);
     assert.match(code, /AiSearchNamespaceBinding/);
     assert.match(code, /AiSearchInstanceBinding/);
+    assert.match(code, new RegExp(`createCacheRuntime\\(${options.durableObject || options.workflow ? "false" : "true"}, true`));
     assert.doesNotMatch(code, /internalExport|DurableObjectStubTransport|__OpenComputeDoStubTransport/);
     assert.doesNotMatch(code, /\b(class|function|for|if)\b/);
   }
@@ -526,7 +547,7 @@ test("all binding and entrypoint combinations produce valid import-only bridges"
 test("default bridge wraps every enabled ctx.exports cache entrypoint", () => {
   const code = generator.generateBindingWrapper({
     mainModule: "index.js", bindings: [], services: [], durableObject: false,
-    cacheAvailable: true, automaticCacheEnabled: true, cacheFailOpen: true,
+    automaticCacheEnabled: true, cacheFailOpen: true,
     automaticCacheEntrypoints: ["Named", "Api"],
   });
   assert.deepEqual(parseSync("entry.js", code, { sourceType: "module" }).errors, []);

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "0b580b34b748c50b75194eef62264c5ec1f4dad3a6ef362d2264d4a3b463a8f9",
-  "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes test/conformance/baseline.json and non-reference docs",
+  "openComputeRevision": "6bf08b1214badedb9049cb8cae790ee8521f311ab9a9e447dffced453527dab0",
+  "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "5f92b595764892c166b36e61a81ef0b5313178554edefbb0b49a01dad7efb303",
   "workerd": {
     "release": "v1.20260905.0-open-compute-p1.b3e1a278",

--- a/test/conformance/catalog.json
+++ b/test/conformance/catalog.json
@@ -292,6 +292,7 @@
       ],
       "positiveCases": [
         "p0-7::p0_7_real_durable_objects_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources",
         "p3-cf-diff::durable-objects/portable/object"
       ],
       "negativeCases": [
@@ -401,6 +402,7 @@
         "workflow-runtime::workflow_runtime_suspension_timeout_parallel_and_native_errors",
         "workflow-product::durable_execution::production_driver_replays_waits_retries_and_events_after_runtime_restart",
         "workflow-recovery::product_bindings::workflow_step_uses_kv_d1_r2_do_queue_and_replay_preserves_external_effects",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources",
         "p3-cf-diff::workflows/portable/lifecycle"
       ],
       "negativeCases": [
@@ -430,7 +432,8 @@
         "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"
       ],
       "negativeCases": [
-        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"
+        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources"
       ],
       "deviations": [
         "OC-CACHE-001",
@@ -453,6 +456,7 @@
       ],
       "positiveCases": [
         "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources",
         "p3-cf-diff::cache-api/portable/cache-hit"
       ],
       "negativeCases": [
@@ -479,7 +483,8 @@
         }
       ],
       "positiveCases": [
-        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"
+        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources"
       ],
       "negativeCases": [
         "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"
@@ -515,6 +520,7 @@
       ],
       "positiveCases": [
         "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources",
         "p5-search::p5_real_vectorize_ai_search_and_markdown_matrix"
       ],
       "negativeCases": [
@@ -541,7 +547,8 @@
         }
       ],
       "positiveCases": [
-        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"
+        "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix",
+        "p3-services-events::p3_service_calls_from_queue_cron_do_and_workflow_event_sources"
       ],
       "negativeCases": [
         "p3-cache-images::p3_cache_images_real_runtime_semantics_and_lifecycle_matrix"

--- a/test/conformance/check.ts
+++ b/test/conformance/check.ts
@@ -66,14 +66,19 @@ function digest(path: string): string {
   return sha256(readFileSync(join(ROOT, path)));
 }
 
+function sourceIdentityExcluded(name: string): boolean {
+  return name.split("/").includes("__pycache__")
+    || name === "test/conformance/baseline.json"
+    || (name.startsWith("docs/") && !name.startsWith("docs/references/"));
+}
+
 function sourceIdentity(): string {
   const names = execFileSync("git", ["-c", "core.excludesFile=/dev/null", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], {
     cwd: ROOT,
   }).subarray(0, -1).toString("utf8").split("\0").filter(Boolean).sort();
   const output = createHash("sha256");
   for (const name of names) {
-    if (name === "test/conformance/baseline.json"
-        || (name.startsWith("docs/") && !name.startsWith("docs/references/"))) continue;
+    if (sourceIdentityExcluded(name)) continue;
     output.update(name);
     output.update("\0");
     const path = join(ROOT, name);

--- a/test/conformance/differential.ts
+++ b/test/conformance/differential.ts
@@ -675,7 +675,9 @@ async function sourceIdentity(): Promise<string> {
   const untracked = await command("git", ["ls-files", "-z", "--others", "--exclude-standard"], {
     cwd: ROOT, env, timeout: 30_000,
   });
-  const names = [...new Set(`${tracked.stdout}\0${untracked.stdout}`.split("\0").filter(Boolean))].sort();
+  const names = [...new Set(`${tracked.stdout}\0${untracked.stdout}`.split("\0").filter(Boolean))]
+    .filter(name => !name.split("/").includes("__pycache__"))
+    .sort();
   const digest = createHash("sha256").update("open-compute-working-tree/v2\0");
   for (const name of names) {
     const path = resolve(ROOT, name);

--- a/test/gate.py
+++ b/test/gate.py
@@ -312,6 +312,10 @@ def digest(path):
         return hashlib.file_digest(file, 'sha256').hexdigest()
 
 
+def source_identity_excluded(name):
+    return '__pycache__' in Path(os.fsdecode(name)).parts
+
+
 def source_identity():
     names = subprocess.check_output(
         ['git', '-c', 'core.excludesFile=/dev/null', 'ls-files', '-z', '--cached', '--others',
@@ -319,6 +323,8 @@ def source_identity():
     ).split(b'\0')
     result = hashlib.sha256()
     for name in sorted(set(names) - {b''}):
+        if source_identity_excluded(name):
+            continue
         # Designs/history are not runtime inputs. Maintained references include
         # embedded runbooks and conformance fixtures, so they must remain frozen.
         if name.startswith(b'docs/') and not name.startswith(b'docs/references/'):
@@ -731,7 +737,8 @@ def main():
     directory = ROOT / '.temp/gate-run' / run_id
     directory.mkdir(parents=True, mode=0o700)
     report = {**plan, 'source_sha256': source,
-        'source_scope': 'repository inputs including docs/references; excludes unconsumed docs plans/history',
+        'source_scope': ('repository inputs including docs/references; excludes generated Python caches '
+                         'and unconsumed docs plans/history'),
         'revision': subprocess.check_output(
         ['git', 'rev-parse', 'HEAD'], cwd=ROOT, text=True).strip(), 'inputs': inputs,
         'host': platform.platform(), 'cpus': os.cpu_count(),

--- a/test/test_gate.py
+++ b/test/test_gate.py
@@ -444,9 +444,10 @@ class GateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn('coverage runs exactly once', result.stderr.decode())
 
-    def test_source_freeze_ignores_designs_but_includes_code_and_consumed_references(self):
+    def test_source_freeze_ignores_designs_and_python_caches_but_includes_runtime_inputs(self):
         names = ['crates/service/src/resources.rs', 'docs/references/runbooks/install.md',
-                 'docs/plan.md', 'docs/implemented/report.md']
+                 'docs/plan.md', 'docs/implemented/report.md',
+                 'test/__pycache__/gate.cpython-314.pyc']
         with tempfile.TemporaryDirectory() as temp, \
              patch.object(gate, 'ROOT', Path(temp)), \
              patch.object(gate.subprocess, 'check_output',


### PR DESCRIPTION
Fixes #19.

## Summary

- expose configured Images, AI, Version Metadata, and other declared bindings in Durable Object and Workflow environments
- keep the global programmatic Cache API available in Worker, Durable Object, and Workflow contexts while disabling only automatic Workers Caching for Durable Object and Workflow invocations
- cover the execution-context matrix with wrapper tests and a real pinned-workerd service-event regression
- ignore generated `__pycache__` directories in source-identity calculations so local Python checks cannot drift the conformance baseline
- document the Cloudflare contract and the remaining hosted Workflow differential credential limitation

## Validation

- `bun run --filter @open-compute/runtime typecheck`
- `node_modules/.bin/tsc --project test/conformance/tsconfig.json --noEmit --pretty false`
- focused runtime tests: 20 passed
- `bun run test:js`: 247 passed
- real pinned-workerd `p3_services_events`: passed
- `./test/gate.py p3-contract`: passed
- Python Gate tests: 26 passed
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --keep-going -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo check --workspace --no-default-features`
- `cargo +1.98.0 check --workspace --all-targets`
- `cargo metadata --no-deps --format-version 1`
- `./test/check-boundaries.sh`
- `./test/check-production.py`
- Rust workspace line coverage: 90.02%

Official behavior references:
- https://developers.cloudflare.com/workers/cache/limitations/
- https://developers.cloudflare.com/workers/runtime-apis/cache/
- https://developers.cloudflare.com/workers/runtime-apis/bindings/
- https://developers.cloudflare.com/workflows/examples/wait-for-event/