### PR TITLE
Fix 0.1.3 Linux Clippy qualification

### DIFF
--- a/crates/runtime/src/process.rs
+++ b/crates/runtime/src/process.rs
@@ -110,7 +110,13 @@ impl Drop for ExecImage {
     }
 }
 
-#[cfg_attr(not(target_os = "macos"), allow(clippy::unnecessary_wraps))]
+#[cfg_attr(
+    not(target_os = "macos"),
+    allow(
+        clippy::unnecessary_wraps,
+        reason = "the shared signature must carry errors from the fallible macOS implementation"
+    )
+)]
 fn exec_path_for(
     file: &mut File,
     staging_lease: Option<(&Path, &str)>,
@@ -271,7 +277,13 @@ pub(crate) fn clear_staging_journal(lease_path: &Path) -> Result<(), PlatformErr
     crate::fsutil::remove_file_nofollow(&path)
 }
 
-#[cfg_attr(not(target_os = "macos"), allow(clippy::unnecessary_wraps))]
+#[cfg_attr(
+    not(target_os = "macos"),
+    allow(
+        clippy::unnecessary_wraps,
+        reason = "the shared signature must carry errors from the fallible macOS implementation"
+    )
+)]
 pub(crate) fn recover_unleased_staging(
     lease_path: &Path,
     expected_digest: &str,

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "c2469ea1f9c05aab2dae10ba7fc505f277a5196d1379f8398a687c0fe1b01a4f",
+  "openComputeRevision": "4ee738245f30132f70dc866ccd33e431e7611b8c1c7968ed72854dd2fd08f221",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
Adds required reasons to the two platform-conditional Clippy allowances that failed the first v0.1.3 release run, and refreshes the conformance source identity. Local static checks, 90.25% coverage, and the complete 51-target workspace Gate pass on the corrected source.