### PR TITLE
Re-release open-compute 0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
           OPEN_COMPUTE_TEST_OCD="$destination" \
             ./test/gate.py single-binary --jobs 1
       - name: Exercise the packaged Dashboard against the candidate executable
-        if: matrix.target == 'linux-x64'
+        if: matrix.target == 'linux-arm64'
         shell: bash
         env:
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
@@ -310,7 +310,7 @@ jobs:
           set -euo pipefail
           evidence="$GITHUB_WORKSPACE/.temp/dashboard-e2e"
           mkdir -p "$evidence"
-          candidate="$RUNNER_TEMP/ocd-$RELEASE_TAG-linux-x64"
+          candidate="$RUNNER_TEMP/ocd-$RELEASE_TAG-linux-arm64"
           OPEN_COMPUTE_OCD_BIN="$candidate" \
             ./scripts/dev-test.sh run >"$evidence/ocd.log" 2>&1 &
           server_pid=$!

--- a/crates/service/src/wrangler_launcher_tests.rs
+++ b/crates/service/src/wrangler_launcher_tests.rs
@@ -337,7 +337,12 @@ async fn unique_running_local_instance_supplies_config_token_listener_and_accoun
     let _ = fs::remove_dir_all(&runtime_root);
     let runtime = runtime_dir_for(ServiceScope::User, &id, Some(&runtime_root));
     assert!(
-        runtime.join("control.sock").as_os_str().as_encoded_bytes().len() <= 103,
+        runtime
+            .join("control.sock")
+            .as_os_str()
+            .as_encoded_bytes()
+            .len()
+            <= 103,
         "control socket path must fit macOS sockaddr_un"
     );
     let startup_id = StartupId::generate();

--- a/crates/service/src/wrangler_launcher_tests.rs
+++ b/crates/service/src/wrangler_launcher_tests.rs
@@ -330,8 +330,16 @@ async fn unique_running_local_instance_supplies_config_token_listener_and_accoun
         .register(&canonical, ServiceScope::User, SystemTime::now())
         .unwrap();
     let id = InstanceId::from_canonical_config_path(&canonical).unwrap();
-    let runtime_root = temp.path().join("runtime");
+    // Keep the override root on `/tmp`: macOS sockaddr_un caps paths at 103 bytes, and
+    // tempfile directories under TMPDIR routinely exceed that once instance_id and
+    // control.sock are appended (same constraint as fallback_user_runtime_root).
+    let runtime_root = PathBuf::from("/tmp").join(format!("oc-wrl-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&runtime_root);
     let runtime = runtime_dir_for(ServiceScope::User, &id, Some(&runtime_root));
+    assert!(
+        runtime.join("control.sock").as_os_str().as_encoded_bytes().len() <= 103,
+        "control socket path must fit macOS sockaddr_un"
+    );
     let startup_id = StartupId::generate();
     let descriptor = build_descriptor(
         &id,
@@ -398,6 +406,7 @@ async fn unique_running_local_instance_supplies_config_token_listener_and_accoun
 
     polling.store(false, Ordering::Release);
     control_thread.join().unwrap();
+    let _ = fs::remove_dir_all(&runtime_root);
 }
 
 #[test]

--- a/docs/releases/0.1.3.md
+++ b/docs/releases/0.1.3.md
@@ -17,6 +17,7 @@ This release is intended for individual operators and small teams that want fami
 - Service Binding WebSocket handoff now preserves the upgraded connection path instead of losing the runtime response during proxying.
 - Runtime event contexts expose the supported capability surface consistently.
 - Dashboard imports use filename casing that works on Linux case-sensitive filesystems.
+- Dashboard operator sign-in no longer crashes with a React update-depth loop after the jotai toast-sink refactor; packaged Dashboard e2e exercises the embedded SPA again.
 - Instance control sockets keep a bounded path when the host provides a long temporary-directory path.
 - Release validation reads version notes from the authoritative `docs/releases/` directory.
 - Python Dynamic Workers on the certified compatibility date use a formally pinned Pyodide bundle embedded as gzip in the single `ocd` executable. Runtime materialization verifies both archive and bundle digests before workerd loads the local private cache.
@@ -61,11 +62,11 @@ The installer verifies `release.json` and `SHA256SUMS`, refuses to replace a bin
 
 ## Downloads
 
-| Host | Asset |
-| --- | --- |
+| Host                   | Asset                     |
+| ---------------------- | ------------------------- |
 | macOS on Apple silicon | `ocd-v0.1.3-darwin-arm64` |
-| Linux on ARM64 | `ocd-v0.1.3-linux-arm64` |
-| Linux on x86-64 | `ocd-v0.1.3-linux-x64` |
+| Linux on ARM64         | `ocd-v0.1.3-linux-arm64`  |
+| Linux on x86-64        | `ocd-v0.1.3-linux-x64`    |
 
 The release also includes `release.json` and `SHA256SUMS`. Each executable embeds the pinned `v1.20260905.0-open-compute-p1.b3e1a278` runtime (`workerd 2026-09-05`) and the Pyodide `314.0.6_2026-08-17_2` bundle selected by the certified `2026-09-08` compatibility date. Production startup performs no runtime download, and the certified Python path loads its bundle locally. Windows and Intel macOS do not have qualified 0.1.3 binaries.
 

--- a/packages/dashboard/src/features/toast/toast-atoms.ts
+++ b/packages/dashboard/src/features/toast/toast-atoms.ts
@@ -8,7 +8,8 @@ const toastSinkAtom = atom<ToastSink | null>(null);
 export const setToastSinkAtom = atom(
   null,
   (_get, set, sink: ToastSink | null) => {
-    set(toastSinkAtom, sink);
+    // jotai treats a function value as an updater — wrap so the sink itself is stored
+    set(toastSinkAtom, () => sink);
   },
 );
 


### PR DESCRIPTION
## Summary
Promote current `main` into `release` to re-cut `v0.1.3` after the previous tag workflow failed.

Includes:
- Dashboard login white-screen fix (jotai toast sink treated as updater)
- Packaged Dashboard e2e moved to `linux-arm64`
- Coverage Gate fix: wrangler launcher control socket path kept under `/tmp` for macOS `sockaddr_un`
- Release notes note for the Dashboard login fix

## Verification
- Local Dashboard Playwright e2e: **32/32 passed** against release `ocd` on `127.0.0.1:18787`
- Main CI green on tip `720463fe`

## After merge
Maintainer will move annotated `v0.1.3` to the new release merge commit (no public GitHub Release exists yet for this tag) and push the tag to re-trigger release.yml.