### PR TITLE
Re-cut open-compute 0.1.3 (p0-2 + arm64 Chrome)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,9 @@ jobs:
             wait "$server_pid" 2>/dev/null || true
           }
           trap cleanup EXIT
+          # ubuntu-24.04-arm images do not ship Google Chrome; Playwright's
+          # chrome channel needs an explicit install (linux-x64 runners already have it).
+          bunx --cwd packages/dashboard playwright install --with-deps chrome
           bun run test:dashboard:e2e
       - uses: actions/upload-artifact@v7
         with:

--- a/crates/service/tests/p0_2_runtime_gate/wrangler.rs
+++ b/crates/service/tests/p0_2_runtime_gate/wrangler.rs
@@ -164,13 +164,26 @@ async fn verify_project(
                     .map(|chunk| Ok::<_, Infallible>(Bytes::copy_from_slice(chunk)))
                     .collect::<Vec<_>>(),
             );
-            let response = client
+            let outcome = client
                 .request(request.body(Body::from_stream(stream)).unwrap())
-                .await
-                .unwrap();
+                .await;
             if size > 32 * 1024 {
-                assert_eq!(response.status(), 413);
+                // Oversized bodies may be rejected mid-stream; the peer then resets
+                // before hyper finishes writing (BrokenPipe / connection closed).
+                match outcome {
+                    Ok(response) => assert_eq!(response.status(), 413),
+                    Err(error) => {
+                        let message = error.to_string();
+                        assert!(
+                            message.contains("Broken pipe")
+                                || message.contains("Connection reset")
+                                || message.contains("connection closed"),
+                            "oversized upload must be rejected or reset: {message}"
+                        );
+                    }
+                }
             } else {
+                let response = outcome.unwrap();
                 assert_eq!(response.status(), 200);
                 assert_eq!(
                     to_bytes(Body::new(response.into_body()), 32 * 1024)

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "4ee738245f30132f70dc866ccd33e431e7611b8c1c7968ed72854dd2fd08f221",
+  "openComputeRevision": "ae9580f47827f3bee2730fcc6a9a8a0e8687a7c3598b73649987484c67dea2ba",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
## Summary
Re-cut `v0.1.3` on `release` after main CI green on `e3501ca4`.

- **p0-2 Gate**: tolerate mid-stream reject / BrokenPipe during coverage upload so the Gate does not flake when the peer closes early.
- **Baseline digest**: keep coverage baseline digest alignment for the release package path.
- **Dashboard e2e (arm64)**: install Playwright Chrome for arm64 in `release.yml` so Dashboard e2e can run on ARM runners.

## Validation
- Local `coverage.sh` passed (90.30%).
- Main CI green: https://github.com/elliothux/open-compute/actions/runs/34334770378 (headSha `e3501ca45c376c6c20fdb9a8711252eaeb5e3e38`).

## Tagging
After merge, move annotated tag `v0.1.3` to the release tip (no public GitHub Release yet; re-cut authorized).