### PR TITLE
Re-cut open-compute 0.1.3 (Playwright Chrome install fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,7 @@ jobs:
           trap cleanup EXIT
           # ubuntu-24.04-arm images do not ship Google Chrome; Playwright's
           # chrome channel needs an explicit install (linux-x64 runners already have it).
-          bunx --cwd packages/dashboard playwright install --with-deps chrome
+          packages/dashboard/node_modules/.bin/playwright install --with-deps chrome
           bun run test:dashboard:e2e
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
Re-cut `v0.1.3` after fixing arm64 Dashboard e2e Chrome install in `release.yml`.

- Prior release run failed on `package (linux-arm64)`: `bunx --cwd packages/dashboard playwright ...` treated `packages/dashboard` as a package name and 404'd.
- Fix on main `0d73452c`: install via `packages/dashboard/node_modules/.bin/playwright install --with-deps chrome`.
- Also carries p0-2 BrokenPipe tolerance + baseline digest from `e3501ca4`.

## Validation
- Main CI green: https://github.com/elliothux/open-compute/actions/runs/34337107889 (headSha `0d73452c4cca517af467be61be79154566ce072e`).

## Tagging
After merge, move annotated tag `v0.1.3` to the release tip (no public GitHub Release yet; re-cut authorized). Cancelled prior failing release run 34335150022.