### PR TITLE
re-cut 0.1.3: Playwright Chromium for linux-arm64 Dashboard e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,9 @@ jobs:
           OPEN_COMPUTE_DEPLOYER_TOKEN: dev-deployer-token
           OPEN_COMPUTE_READ_ONLY_TOKEN: dev-read-only-token
           OPEN_COMPUTE_DASHBOARD_E2E_BASE_URL: http://127.0.0.1:18787/operator/
-          OPEN_COMPUTE_DASHBOARD_E2E_BROWSER_CHANNEL: chrome
+          # Google Chrome channel is not supported on Linux Arm64; use Playwright's
+          # bundled Chromium (default when OPEN_COMPUTE_DASHBOARD_E2E_BROWSER_CHANNEL
+          # is unset — see packages/dashboard/playwright.config.ts).
         run: |
           set -euo pipefail
           evidence="$GITHUB_WORKSPACE/.temp/dashboard-e2e"
@@ -319,9 +321,9 @@ jobs:
             wait "$server_pid" 2>/dev/null || true
           }
           trap cleanup EXIT
-          # ubuntu-24.04-arm images do not ship Google Chrome; Playwright's
-          # chrome channel needs an explicit install (linux-x64 runners already have it).
-          packages/dashboard/node_modules/.bin/playwright install --with-deps chrome
+          # Playwright's chrome channel is unavailable on Linux Arm64
+          # ("ERROR: not supported on Linux Arm64"). Install bundled Chromium.
+          packages/dashboard/node_modules/.bin/playwright install --with-deps chromium
           bun run test:dashboard:e2e
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Re-cut v0.1.3 onto release with the Chromium arm64 e2e fix from main (`cd8d2509`).
- Replaces the prior Chrome-channel install (unsupported on Linux Arm64) with Playwright bundled Chromium + `--with-deps`.
- Does not set `OPEN_COMPUTE_DASHBOARD_E2E_BROWSER_CHANNEL` so `playwright.config.ts` uses bundled chromium.

## Main CI
https://github.com/elliothux/open-compute/actions/runs/34340213250 (success)

## Test plan
- [ ] release.yml package (linux-arm64) installs chromium (not chrome)
- [ ] Dashboard e2e passes on arm64
- [ ] Note coverage outcome
- [ ] Force-move annotated tag `v0.1.3` to merge commit after merge