### PR TITLE
re-cut 0.1.3: refresh conformance source digest after Chromium arm64 e2e

### DIFF
--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "ae9580f47827f3bee2730fcc6a9a8a0e8687a7c3598b73649987484c67dea2ba",
+  "openComputeRevision": "050170e34759e318fdafc7aa97788f17d5fea39d2a633a73b2741492c77321ed",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
## Summary
- Refresh `openComputeRevision` in `test/conformance/baseline.json` to the post-Chromium-arm64-e2e source digest (`050170e34759e318fdafc7aa97788f17d5fea39d2a633a73b2741492c77321ed`).
- Fixes release coverage `p3-contract` baseline-identity drift from run 34341027089.
- Local `./test/gate.py p3-contract --jobs 1` PASS; `./test/coverage.sh --jobs 2` EXIT 0 at 90.31%.

## Test plan
- [x] Local p3-contract PASS
- [x] Local coverage ≥90%
- [x] Main CI green
- [ ] Release coverage + linux-arm64 Dashboard e2e + publish after retag