### PR TITLE
re-cut 0.1.3: D1 e2e assert + conformance source digest

### DIFF
--- a/packages/dashboard/tests/e2e/lifecycle.spec.ts
+++ b/packages/dashboard/tests/e2e/lifecycle.spec.ts
@@ -93,7 +93,7 @@ test.describe("operator dashboard live lifecycle", () => {
       .getByLabel("SQL query")
       .fill("CREATE TABLE lifecycle_test (id INTEGER PRIMARY KEY);");
     await page.getByRole("button", { name: "Run query" }).click();
-    await expect(page.getByText(/lifecycle_test|success/i)).toBeVisible({
+    await expect(page.getByText(/"success": true/)).toBeVisible({
       timeout: 15_000,
     });
     await page.getByRole("button", { name: "Create backup" }).click();

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "050170e34759e318fdafc7aa97788f17d5fea39d2a633a73b2741492c77321ed",
+  "openComputeRevision": "6af31dcf9f161dd28224af0cfab3720b3fc1ea0e52b9d449b064a9d5c5f6a157",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
## Summary
- Harden D1 dashboard e2e success assert to match only `"success": true` (avoids Playwright strict-mode race with SQL textarea matching `/lifecycle_test|success/i`).
- Refresh `openComputeRevision` to `6af31dcf9f161dd28224af0cfab3720b3fc1ea0e52b9d449b064a9d5c5f6a157`.
- Keeps Playwright Chromium on linux-arm64 (no chrome channel).

## Test plan
- [x] Local p3-contract PASS
- [x] Local coverage EXIT 0 at 90.30%
- [x] Main CI green
- [ ] Release coverage + linux-arm64 Dashboard e2e + publish