### PR TITLE
fix: disable artifact repository reflogs

### DIFF
--- a/crates/artifacts/src/git_repo.rs
+++ b/crates/artifacts/src/git_repo.rs
@@ -117,7 +117,7 @@ impl GitRepositoryStore {
             )?;
             write_private_file(
                 &path.join("config"),
-                b"[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n\tlogallrefupdates = true\n",
+                b"[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n",
             )?;
             write_private_file(
                 &path.join("description"),

--- a/crates/artifacts/src/git_repo/tests.rs
+++ b/crates/artifacts/src/git_repo/tests.rs
@@ -50,6 +50,7 @@ fn initialize_push_read_fork_and_source_delete_preserve_objects() {
     run(&work, &["add", "README.md"]);
     run(&work, &["commit", "-m", "first"]);
     run(&work, &["push", "origin", "main"]);
+    assert!(!store.path(source).join("logs").exists());
 
     let head = store.resolve_revision(source, "main").unwrap();
     let tree = run_output(&work, &["rev-parse", "HEAD^{tree}"]);

--- a/docs/releases/0.1.4.md
+++ b/docs/releases/0.1.4.md
@@ -15,6 +15,7 @@ This release is intended for single-machine operators who need Cloudflare-compat
 ## Fixed
 
 - `scripts/install.sh` now checks both the binary and install-receipt directories before making any release network request. An unwritable system prefix reports exact system-wide and per-user commands instead of downloading assets and then exposing a raw `mkdir` failure.
+- Artifact bare repositories no longer enable local reflogs, avoiding platform-specific receive-pack failures while preserving refs and immutable Git objects.
 - The Dashboard login toast sink no longer passes a function through Jotai's updater semantics, avoiding a render update-depth loop after sign-in.
 - Linux ARM64 Dashboard qualification uses the repository-local Playwright Chromium executable, and runtime/Wrangler tests use bounded paths and stricter success assertions across supported hosts.
 

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "afbb48a7e329d8bd8a5447e88da418b601a5de14867e73093b9a798fcff1a1f7",
+  "openComputeRevision": "0d67601bb78149b25c30f6e4a0aa3bcde6e89a8d872d944b4c882cfe53417686",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
## Summary

- remove unnecessary reflog creation from Day1 Artifact bare repositories
- prevent platform-specific receive-pack transaction failures
- assert pushes preserve refs and objects without creating reflogs

## Verification

- focused Artifact file and HTTP Git tests passed
- Cloudflare compatibility review: no findings
- local workspace Gate: 51 targets, one round, passed
- local Rust line coverage: 90.02%
- main CI: passed (run 34443366309)