### PR TITLE
release: fix v0.1.4 runtime recovery and qualification latency

### DIFF
--- a/.github/actions/setup-open-compute/action.yml
+++ b/.github/actions/setup-open-compute/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Save newly built dependencies after success or failure
     required: false
     default: "true"
+  rust-cache-targets:
+    description: Cache Cargo target directories; disable when sccache owns compiler outputs
+    required: false
+    default: "true"
   rust-workspaces:
     description: rust-cache workspace to target-dir mapping
     required: false
@@ -67,6 +71,17 @@ runs:
         toolchain: 1.98.0
         components: ${{ inputs.rust-components }}
 
+    - name: Cache Cargo downloads
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+        key: ${{ runner.os }}-cargo-downloads-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-downloads-
+
     - name: Install cargo-llvm-cov
       if: ${{ inputs.llvm-cov == 'true' }}
       uses: taiki-e/install-action@cargo-llvm-cov
@@ -74,7 +89,7 @@ runs:
     - name: Cache Rust
       uses: Swatinem/rust-cache@v2
       with:
-        cache-targets: true
+        cache-targets: ${{ inputs.rust-cache-targets }}
         cache-on-failure: true
         save-if: ${{ github.event_name != 'pull_request' && inputs.rust-cache-save == 'true' }}
         add-job-id-key: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/setup-open-compute
         with:
           rust-cache-key: default
-          rust-components: rustfmt
+          rust-components: rustfmt, clippy
       - name: Build and typecheck current runtime and tooling assets
         run: bun run build
       - name: Fast JavaScript and Gate tooling tests
@@ -37,10 +37,16 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s test -p 'test_gate.py'
       - name: fmt
         run: cargo fmt --all --check
+      - name: clippy
+        run: ./test/check-rust-clippy.sh
+      - name: no-default-features
+        run: cargo check --workspace --no-default-features
       - name: Rust 1.98 workspace and target compile check
-        run: cargo check --workspace --all-targets
+        run: cargo +1.98.0 check --workspace --all-targets
       - name: metadata
         run: cargo metadata --no-deps --format-version 1
+      - name: Production feature and artifact hygiene
+        run: ./test/check-production.py
       - name: dependency boundaries
         run: ./test/check-boundaries.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,8 @@ jobs:
       - uses: ./.github/actions/setup-open-compute
         with:
           rust-cache-key: release-${{ matrix.target }}
+          rust-cache-save: "false"
+          rust-cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.11
         with:
           version: v0.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,60 +120,8 @@ jobs:
             --json databaseId --jq 'length')"
           test "$count" -gt 0
 
-  msrv:
-    needs: validate
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          lfs: true
-      - uses: ./.github/actions/setup-open-compute
-        with:
-          rust-cache-key: default
-          rust-cache-save: "false"
-          python: "false"
-          node: "false"
-      - name: Build untracked runtime and toolchain assets from this checkout
-        run: bun run build
-      - name: MSRV 1.98 check
-        run: cargo check --workspace --all-targets
-
-  lint-test:
-    needs: validate
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-15]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          lfs: true
-      - uses: ./.github/actions/setup-open-compute
-        with:
-          rust-cache-key: default
-          rust-components: rustfmt, clippy
-      - name: Strict TypeScript and generated runtime assets
-        run: |
-          bun run build
-          bun run check:generated
-          bun run test:js:ci
-          PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s test -p 'test_gate.py'
-      - name: fmt
-        run: cargo fmt --all --check
-      - name: clippy
-        run: ./test/check-rust-clippy.sh
-      - name: no-default-features
-        run: cargo check --workspace --no-default-features
-      - name: metadata
-        run: cargo metadata --no-deps --format-version 1
-      - name: Production feature and artifact hygiene
-        run: ./test/check-production.py
-      - name: dependency boundaries
-        run: chmod +x test/check-boundaries.sh && ./test/check-boundaries.sh
-
   coverage:
-    needs: [validate, msrv, lint-test]
+    needs: validate
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
@@ -201,7 +149,7 @@ jobs:
             target/llvm-cov/lcov.info
 
   integration:
-    needs: [validate, msrv, lint-test, coverage]
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -221,9 +169,9 @@ jobs:
       - name: Final workspace once (macOS)
         if: runner.os == 'macOS'
         run: ./test/gate.py --workspace --jobs 2
-      - name: Final workspace and controlled egress (Linux, explicit privilege authorization)
+      - name: Controlled P0.2 egress only (Linux, explicit privilege authorization)
         if: runner.os == 'Linux'
-        run: OPEN_COMPUTE_EGRESS_FIXTURE_ALLOW_SUDO=1 ./test/test-p0-2-egress-linux.sh --workspace --jobs 2
+        run: OPEN_COMPUTE_EGRESS_FIXTURE_ALLOW_SUDO=1 ./test/test-p0-2-egress-linux.sh p0-2 --jobs 2
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -403,7 +351,7 @@ jobs:
           compression-level: 0
 
   publish:
-    needs: [validate, assemble, msrv, lint-test, coverage, integration]
+    needs: [validate, assemble, coverage, integration]
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/crates/runtime/src/compile.rs
+++ b/crates/runtime/src/compile.rs
@@ -4,7 +4,7 @@ use crate::digest::digest_for_with_tokens_and_policy;
 use crate::fsutil::{
     FILE_MODE, MAX_LOCK_BYTES, WorkDir, chmod, contained_in, create_dir_secure, fsync_dir,
     hex_sha256, open_dir_nofollow, open_nofollow, read_regular_nofollow_bounded,
-    remove_file_strict, rename_noreplace, require_absolute, write_atomic_new,
+    remove_file_nofollow, remove_file_strict, rename_noreplace, require_absolute, write_atomic_new,
 };
 use crate::process::assert_reaped;
 use crate::verify::VerifiedRuntime;
@@ -22,6 +22,63 @@ use std::time::Duration;
 const MAX_COMPILED_BYTES: usize = 16 * 1024 * 1024;
 
 pub use crate::digest::PlatformReleaseMeta;
+
+pub(crate) fn cleanup_interrupted_compile_state(runtime_dir: &Path) -> Result<(), PlatformError> {
+    let directory = open_dir_nofollow(runtime_dir)?;
+    let entries = rustix::fs::Dir::read_from(&directory).map_err(|_| {
+        PlatformError::new(
+            ErrorCode::ConfigCompileFailed,
+            "failed to inspect runtime compile staging",
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|_| {
+            PlatformError::new(
+                ErrorCode::ConfigCompileFailed,
+                "failed to inspect runtime compile staging",
+            )
+        })?;
+        let Ok(name) = entry.file_name().to_str() else {
+            continue;
+        };
+        let path = runtime_dir.join(name);
+        if is_compile_workdir(name) {
+            let _ = open_dir_nofollow(&path)?;
+            fs::remove_dir_all(&path).map_err(|_| {
+                PlatformError::new(
+                    ErrorCode::ConfigCompileFailed,
+                    "failed to recover interrupted runtime compilation",
+                )
+            })?;
+        } else if is_atomic_partial(name) {
+            remove_file_nofollow(&path)?;
+        }
+    }
+    fsync_dir(runtime_dir)
+}
+
+fn is_compile_workdir(name: &str) -> bool {
+    let Some(rest) = name
+        .strip_prefix(".compile.")
+        .or_else(|| name.strip_prefix(".partial."))
+    else {
+        return false;
+    };
+    let Some((digest, id)) = rest.rsplit_once('.') else {
+        return false;
+    };
+    digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && uuid::Uuid::parse_str(id).is_ok_and(|id| id.get_version_num() == 7)
+}
+
+fn is_atomic_partial(name: &str) -> bool {
+    name.strip_prefix(".partial.")
+        .and_then(|id| uuid::Uuid::parse_str(id).ok())
+        .is_some_and(|id| id.get_version_num() == 7)
+}
 
 /// Inputs required to compile or reuse a binary config.
 pub struct CompileRequest<'a> {

--- a/crates/runtime/src/embedded.rs
+++ b/crates/runtime/src/embedded.rs
@@ -1,5 +1,6 @@
 //! The only production runtime source: this executable's pinned, offline payload.
 
+use crate::compile::cleanup_interrupted_compile_state;
 use crate::fsutil::{
     StagingDir, create_dir_secure, fsync_dir, hash_bytes, hash_file, open_dir_nofollow,
     open_nofollow, parse_sha256_hex, read_regular_nofollow, rename_noreplace,
@@ -103,6 +104,7 @@ impl RuntimePackage {
 /// Staging is private, same-filesystem, fsynced, and atomically published without overwrite.
 pub fn materialize_embedded_runtime(runtime_dir: &Path) -> Result<RuntimePackage, PlatformError> {
     let _ = open_dir_nofollow(runtime_dir)?;
+    cleanup_interrupted_compile_state(runtime_dir)?;
     let packages = runtime_dir.join("packages");
     create_dir_secure(&packages)?;
     cleanup_partial_packages(&packages)?;

--- a/crates/runtime/src/embedded_tests.rs
+++ b/crates/runtime/src/embedded_tests.rs
@@ -145,6 +145,42 @@ fn interrupted_materialization_cleanup_is_bounded_and_does_not_follow_links() {
 }
 
 #[test]
+fn interrupted_compile_cleanup_removes_only_owned_staging() {
+    let dir = tempfile::tempdir().unwrap();
+    let digest = "a".repeat(64);
+    let compile = dir
+        .path()
+        .join(format!(".compile.{digest}.{}", uuid::Uuid::now_v7()));
+    let partial = dir
+        .path()
+        .join(format!(".partial.{digest}.{}", uuid::Uuid::now_v7()));
+    let atomic = dir
+        .path()
+        .join(format!(".partial.{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir(&compile).unwrap();
+    std::fs::create_dir(&partial).unwrap();
+    std::fs::write(compile.join("config.capnp"), b"incomplete").unwrap();
+    std::fs::write(partial.join("config.bin"), b"incomplete").unwrap();
+    std::fs::write(&atomic, b"incomplete").unwrap();
+    let retained = dir.path().join(".partial.not-owned");
+    std::fs::write(&retained, b"retained").unwrap();
+
+    cleanup_interrupted_compile_state(dir.path()).unwrap();
+
+    assert!(!compile.exists());
+    assert!(!partial.exists());
+    assert!(!atomic.exists());
+    assert_eq!(std::fs::read(&retained).unwrap(), b"retained");
+
+    let outside = tempfile::tempdir().unwrap();
+    let linked = dir
+        .path()
+        .join(format!(".partial.{digest}.{}", uuid::Uuid::now_v7()));
+    symlink(outside.path(), &linked).unwrap();
+    assert!(cleanup_interrupted_compile_state(dir.path()).is_err());
+}
+
+#[test]
 fn unpack_rejects_invalid_archives_and_wrong_payload_hashes() {
     let dir = tempfile::tempdir().unwrap();
     assert!(

--- a/docs/references/ci-build-performance.md
+++ b/docs/references/ci-build-performance.md
@@ -15,10 +15,12 @@ package 在编译后执行无 `--config` 的 capabilities 命令失败。两个 
 
 ## 当前执行分工
 
-- `main`、`release` 和普通 PR：同一 runner 完成 build/typecheck、快速工具测试、format、
-  Rust 1.98 compile check、metadata 和边界检查。完整 workspace/coverage 不再重复排入每个开发提交。
-- tag qualification：静态检查 → coverage → 一个完整最终 workspace Gate；保持 90% 门槛和受控 egress。
-- 三个正式平台 package：身份验证后即并行构建，和 qualification 重叠；publish 等待两条路径全部成功。macOS Intel 不再进入 package 矩阵。
+- `main` 和普通 PR：同一 runner 完成 build/typecheck、快速工具测试、format、clippy、
+  no-default-features、Rust 1.98 compile check、production hygiene、metadata 和边界检查。release tag
+  校验精确 source commit 已通过该静态资格，不再重跑。
+- tag qualification：coverage、一个 macOS 完整最终 workspace Gate 和 Linux `p0-2` 受控 egress
+  在身份校验后并行启动；Linux egress 不再重复 `--workspace`。
+- 三个正式平台 package：身份验证后即并行构建，和全部 qualification 重叠；publish 等待所有路径成功。macOS Intel 不再进入 package 矩阵。
 - package 与普通 production hygiene 使用同一 executable verifier，生成 mode 0600 临时配置再查询
   capabilities，同时核对 release identity、版本、licenses 和嵌入 docs；不初始化平台数据目录。
 - `main` 不保护；`release` 要求 PR、最新 required `ci` 和讨论解决；tag 必须来自通过 CI 的 `release`。
@@ -27,7 +29,8 @@ package 在编译后执行无 `--config` 的 capabilities 命令失败。两个 
 
 - Rust dependency cache 按工具链、OS/CPU、编译环境和 manifest/lock 分隔；release target 与 coverage
   各自使用 profile key。受信任的分支/tag 运行允许失败后保存，PR 不向这些缓存写入。
-- MSRV job 只恢复依赖缓存，避免较小的 check 结果抢先占用其他 job 的不可覆盖缓存条目。
+- Cargo registry/index/git 下载使用独立、仅由 OS 与 `Cargo.lock` 定位的缓存，避免 profile-specific
+  target cache 未命中时重新下载全部 Rust 依赖。
 - package 使用固定 sccache 0.16.0，512 MiB 本地缓存位于 `.temp/sccache`，整目录通过 Actions
   cache restore/save 复用；主 key 包含源码/run/attempt，fallback 保持相同 OS/CPU、工具链和锁文件。
   成功和失败均保存。它是编译加速缓存，不是测试通过证据或可信发行物。

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -119,6 +119,8 @@ git push origin vX.Y.Z
 
 每个 Gate job 都先显式执行 `bun run build` 和 `cargo fetch --locked`；打包脚本独立从源码构建。
 最终 Gate 不设置三轮诊断变量，遵循[单轮测试政策](testing.md)。
+共享 setup 将 Cargo registry/git 下载与编译产物分开缓存：下载缓存允许 `Cargo.lock` 变化时按 OS 回退，
+coverage 保留独立 instrumented target cache；package 只使用 bounded sccache，不重复保存 Cargo target。
 
 push tag 是唯一发布触发器。随后在 GitHub Actions 的 `release` workflow 中确认所有 qualification、
 三个正式目标 package 和 `publish` job 成功，并在 GitHub Release 页面核对五个 assets。仓库已配置以下设置（2026-09-06 按用户要求迁移）：

--- a/docs/references/releasing.md
+++ b/docs/references/releasing.md
@@ -31,9 +31,10 @@ Rust/Bun/Bazel 工具链，从源码手动编译，并显式提供与正式 lock
 
 ## 两条工作流
 
-`.github/workflows/ci.yml` 只在 `main` push 和以 `main` 为 base 的 pull request 上执行轻量检查：
-显式 runtime/tooling build 与 typecheck、快速 JS/Python 测试、format、Rust 1.98 workspace/all-targets
-check、metadata 和依赖边界。普通 CI 不执行完整 workspace Gate、coverage 或发行打包。
+`.github/workflows/ci.yml` 只在 `main` push 和以 `main` 为 base 的 pull request 上执行静态资格：
+显式 runtime/tooling build 与 typecheck、快速 JS/Python 测试、format、clippy、no-default-features、
+Rust 1.98 workspace/all-targets check、production hygiene、metadata 和依赖边界。普通 CI 不执行完整
+workspace Gate、coverage 或发行打包。
 release PR 复用其 main head 已通过的 push check，不再重复执行相同检查；tag 触发的 release workflow
 会校验 release merge commit 对应的 main source commit 已通过该 pre-check。各 PR 与分支使用独立
 concurrency group，取消过期运行；汇总 job `ci` 是 `release` 分支的 required check。
@@ -52,11 +53,13 @@ concurrency group，取消过期运行；汇总 job `ci` 是 `release` 分支的
    What's new、Fixed、Before you upgrade、Install or upgrade、Downloads、Security、Known limitations 和
    Verification 八个章节；不得保留 TODO、TBD 或 PLACEHOLDER。
 
-校验通过后，release workflow 才执行 Linux/macOS 静态检查、90% Rust 行覆盖率、完整单轮
-最终 workspace Gate（coverage 成功后执行），以及 Linux 受控 egress fixture。三个原生 runner 在身份校验后立即并行使用正式
-workerd lock 打包自己的 `ocd`，并以 `OPEN_COMPUTE_TEST_OCD` 跑单文件隔离、首启、重启和损坏拒绝测试。
+校验通过后，release workflow 并行执行 90% Rust 行覆盖率、macOS 上完整单轮最终 workspace Gate、
+Linux 上仅 `p0-2` 受控 egress fixture，以及三个正式平台打包。Linux egress 不再夹带第二轮
+`--workspace`；静态资格直接复用 release source commit 已通过的 main `ci`，不在 tag workflow 重跑。
+三个原生 runner 使用正式 workerd lock 打包自己的 `ocd`，并以 `OPEN_COMPUTE_TEST_OCD` 跑单文件隔离、
+首启、重启和损坏拒绝测试。
 
-打包可以与资格验证并行，但 `publish` 明确依赖全部静态检查、coverage、最终 Gate 和三个正式平台 assemble；
+`publish` 明确依赖 main 静态资格、coverage、macOS 最终 Gate、Linux egress 和三个正式平台 assemble；
 任何一项未通过均不得公开发布。失败构建保存缓存、编译耗时和标明未验收的二进制，不作为公开发行物。
 缓存和任务依赖设计见 [CI 构建性能](ci-build-performance.md)。
 
@@ -87,18 +90,21 @@ vinext/Next.js 端到端或 hosted Cloudflare differential。其冻结摘要和�
    git lfs push origin --all
    ```
 
-4. 在版本候选源码冻结后，先在本地干净 checkout 执行一次 coverage preflight。必须显式准备正式
-   workerd，先运行 `bun run build`，再用宿主对应的 `OPEN_COMPUTE_TEST_WORKERD` 执行
-   `./test/coverage.sh --jobs 2`；90% Rust 行覆盖率和其中的单轮 workspace Gate 都必须通过。保存失败
-   证据，不自动重试；这次本地 coverage 是发版前的单轮拦截，不替代 tag workflow 的独立 coverage。
+4. 在版本候选源码冻结后，先在本地干净 checkout 完成发布预检。必须显式准备正式 workerd，先运行
+   `bun run build` 和静态检查，再用宿主对应的 `OPEN_COMPUTE_TEST_WORKERD` 依次执行一次
+   `./test/coverage.sh --jobs 2` 与一次 `./test/gate.py --workspace --jobs 2`。coverage 的插桩 Gate 和最终
+   未插桩 Gate 各有不同验收职责；除此之外不再运行重复 aggregate。90% Rust 行覆盖率和最终 Gate
+   必须通过后才能 push/tag。保存失败证据，不自动重试；本地预检用于尽早拦截，不替代 tag workflow
+   的独立 runner 资格。
 5. 新建 `docs/releases/X.Y.Z.md` 并加入 `docs/releases/README.md`。写法参考成熟自托管项目的
    operator-first release notes：开头用一段话说明这版解决什么问题、适合谁；随后按 What's new 和 Fixed 归纳用户可感知的变化；
    Before you upgrade 必须明确数据/配置兼容性、是否需要停机或人工动作，即使答案是“无”；Install or upgrade 给出可直接执行的
    版本固定命令；Downloads 列出支持平台和精确资产名；Security 明确安全公告或“无已知公告”；Known limitations 只列会影响部署决策的
    现实边界；Verification 只能陈述这个 revision 实际完成的资格。最后附完整 diff 链接，PR/commit 列表只能作为补充，不能替代上述内容。
-6. 提交版本变更与 release notes 到 `main`，等待 main 的轻量 `ci` 通过。main CI 只做 build、快速 JS/Python、fmt、
-   workspace check、metadata 和边界检查；clippy、no-default-features、coverage、完整 workspace
-   Gate、三个正式平台打包和发布验证由 tag 触发的 release workflow 负责；
+6. 提交版本变更与 release notes 到 `main`，等待 main 的静态 `ci` 通过。main CI 完成 build、快速
+   JS/Python、fmt、clippy、no-default-features、Rust 1.98 workspace check、production hygiene、metadata
+   和边界检查；coverage、完整 workspace Gate、Linux egress、三个正式平台打包和发布验证由 tag
+   触发的 release workflow 负责；
 7. 以 `main` 为 head、`release` 为 base 创建并合并一个 version PR。`release` 受保护，不能直接
    推送，也不能通过按版本创建临时分支绕过 PR；
 8. 确认 PR 合并产生的精确 `release` commit 已包含通过的 main pre-check，再在干净的本地 `release`
@@ -121,6 +127,8 @@ git push origin vX.Y.Z
 最终 Gate 不设置三轮诊断变量，遵循[单轮测试政策](testing.md)。
 共享 setup 将 Cargo registry/git 下载与编译产物分开缓存：下载缓存允许 `Cargo.lock` 变化时按 OS 回退，
 coverage 保留独立 instrumented target cache；package 只使用 bounded sccache，不重复保存 Cargo target。
+release 的 coverage、最终 Gate、Linux egress 与 package 只依赖身份校验并同时启动，发布墙钟由最慢路径
+决定，不再把这些长任务串行相加。
 
 push tag 是唯一发布触发器。随后在 GitHub Actions 的 `release` workflow 中确认所有 qualification、
 三个正式目标 package 和 `publish` job 成功，并在 GitHub Release 页面核对五个 assets。仓库已配置以下设置（2026-09-06 按用户要求迁移）：

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "22cc7dc72e9a9e4f9e4a4e13ccefa869dc67cd8ad0681cac7772d49ed6b791f8",
+  "openComputeRevision": "c0c55c3c2c458d921310d25e8f1889ae6cd3d30d68c3bdb18ffab557af2464b2",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "0d67601bb78149b25c30f6e4a0aa3bcde6e89a8d872d944b4c882cfe53417686",
+  "openComputeRevision": "22cc7dc72e9a9e4f9e4a4e13ccefa869dc67cd8ad0681cac7772d49ed6b791f8",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {

--- a/test/release-tools.test.mjs
+++ b/test/release-tools.test.mjs
@@ -34,6 +34,9 @@ const execFileAsync = promisify(execFile);
 const installerPath = fileURLToPath(
   new URL("../scripts/install.sh", import.meta.url),
 );
+const releaseWorkflowPath = fileURLToPath(
+  new URL("../.github/workflows/release.yml", import.meta.url),
+);
 
 async function writeTestCommand(directory, name, source) {
   await writeFile(join(directory, name), source, { mode: 0o755 });
@@ -151,6 +154,22 @@ test("release tags are stable SemVer and match the workspace version", () => {
   ]) {
     assert.throws(() => stableVersionFromTag(tag));
   }
+});
+
+test("release qualification runs long checks in parallel without a second Linux workspace Gate", async () => {
+  const workflow = await readFile(releaseWorkflowPath, "utf8");
+  assert.match(workflow, /  coverage:\n    needs: validate\n/);
+  assert.match(workflow, /  integration:\n    needs: validate\n/);
+  assert.equal(
+    workflow.match(/\.\/test\/gate\.py --workspace --jobs 2/g)?.length,
+    1,
+  );
+  assert.match(
+    workflow,
+    /test-p0-2-egress-linux\.sh p0-2 --jobs 2/,
+  );
+  assert.doesNotMatch(workflow, /test-p0-2-egress-linux\.sh --workspace/);
+  assert.doesNotMatch(workflow, /\n  (?:msrv|lint-test):\n/);
 });
 
 test("release assembly requires and describes the exact three native executables", async () => {


### PR DESCRIPTION
## Summary

- recover exact runtime compile staging left by an interrupted startup
- move release static qualification to the required main pre-check
- run coverage, the single macOS workspace Gate, Linux-only P0.2 egress, and native packaging in parallel
- remove the duplicate Linux workspace Gate and retain local coverage/final-Gate preflight

## Verification

- local static checks passed
- local Rust line coverage: 90.02%
- local workspace Gate: 51 targets, one round, passed
- Cloudflare conformance: 14/14 passed
- main CI: 34457688040 passed