### PR TITLE
Make Wrangler major mismatches non-blocking

### DIFF
--- a/crates/service/src/wrangler_launcher.rs
+++ b/crates/service/src/wrangler_launcher.rs
@@ -49,8 +49,10 @@ pub struct WranglerLaunch {
     pub target_kind: &'static str,
     /// Selected target or instance name for summaries.
     pub target_name: String,
-    /// Detected and certified exact Wrangler version.
+    /// Detected project-local Wrangler version.
     pub wrangler_version: String,
+    /// Exact Wrangler version certified by the selected target.
+    pub certified_wrangler_version: String,
     token: SecretString,
 }
 
@@ -59,12 +61,13 @@ impl WranglerLaunch {
     pub fn exec(self, diagnostic: &mut impl Write) -> Result<(), PlatformError> {
         writeln!(
             diagnostic,
-            "WRANGLER_TARGET kind={} name={} origin={} account={} wrangler={}",
+            "WRANGLER_TARGET kind={} name={} origin={} account={} wrangler={} certified_wrangler={}",
             self.target_kind,
             self.target_name,
             origin(&self.api_base_url),
             self.account_id,
-            self.wrangler_version
+            self.wrangler_version,
+            self.certified_wrangler_version
         )
         .map_err(|_| wrangler_invalid("failed to write the Wrangler target summary"))?;
         let mut command = Command::new(&self.executable);
@@ -130,18 +133,14 @@ pub async fn prepare_wrangler_launch(
     let detected_version = detect_wrangler_version(&executable, &cwd)?;
     let capabilities =
         fetch_capabilities_at(http, &execution.api_base_url, &execution.token).await?;
-    if detected_version != capabilities.wrangler_version {
-        writeln!(
+    if version_major(&detected_version) != version_major(&capabilities.wrangler_version) {
+        let _ = writeln!(
             diagnostic,
-            "WRANGLER_VERSION_MISMATCH path={} detected={} expected={}",
+            "WRANGLER_MAJOR_VERSION_MISMATCH path={} detected={} certified={}",
             executable.display(),
             detected_version,
             capabilities.wrangler_version
-        )
-        .map_err(|_| wrangler_invalid("failed to write Wrangler version diagnostics"))?;
-        return Err(wrangler_invalid(
-            "project-local Wrangler version does not match the selected target pin",
-        ));
+        );
     }
     Ok(WranglerLaunch {
         executable,
@@ -152,6 +151,7 @@ pub async fn prepare_wrangler_launch(
         target_kind: execution.kind,
         target_name: execution.name,
         wrangler_version: detected_version,
+        certified_wrangler_version: capabilities.wrangler_version,
         token: execution.token,
     })
 }
@@ -352,7 +352,7 @@ fn resolve_project_wrangler(project: &Path) -> Result<PathBuf, PlatformError> {
         directory = parent.to_path_buf();
     }
     Err(wrangler_invalid(
-        "project-local Wrangler is missing; install the exact certified version",
+        "project-local Wrangler is missing; install Wrangler in the project",
     ))
 }
 
@@ -406,6 +406,16 @@ fn valid_version(value: &str) -> bool {
         && parts
             .iter()
             .all(|part| !part.is_empty() && part.as_bytes().iter().all(u8::is_ascii_digit))
+}
+
+fn version_major(value: &str) -> &str {
+    let major = value.split_once('.').map_or(value, |(major, _)| major);
+    let normalized = major.trim_start_matches('0');
+    if normalized.is_empty() {
+        "0"
+    } else {
+        normalized
+    }
 }
 
 fn origin(api_base_url: &str) -> &str {

--- a/crates/service/src/wrangler_launcher_tests.rs
+++ b/crates/service/src/wrangler_launcher_tests.rs
@@ -175,6 +175,7 @@ async fn remote_launch_preserves_opaque_args_and_uses_nearest_hoisted_binary() {
     );
     assert_eq!(launch.target_kind, "target");
     assert_eq!(launch.wrangler_version, "4.127.1");
+    assert_eq!(launch.certified_wrangler_version, "4.127.1");
     assert!(diagnostic.is_empty());
 
     let command = launch.child_command();
@@ -214,8 +215,71 @@ async fn remote_launch_preserves_opaque_args_and_uses_nearest_hoisted_binary() {
 }
 
 #[tokio::test]
-async fn wrong_version_fails_before_launch_with_secret_free_diagnostics() {
-    let (temp, registry, http, project, name) = remote_fixture("4.126.0");
+async fn same_major_version_drift_launches_without_a_warning() {
+    let (temp, registry, http, project, name) = remote_fixture("4.130.0");
+    let instances = InstanceRegistry::with_roots(
+        temp.path().join("instances/system"),
+        temp.path().join("instances/user"),
+    );
+    let mut diagnostic = Vec::new();
+    let launch = prepare_wrangler_launch(
+        Some(&name),
+        None,
+        None,
+        Some(&project),
+        &[OsString::from("deploy")],
+        temp.path(),
+        &instances,
+        &registry,
+        &http,
+        None,
+        &mut diagnostic,
+    )
+    .await
+    .unwrap();
+    assert_eq!(launch.wrangler_version, "4.130.0");
+    assert_eq!(launch.certified_wrangler_version, "4.127.1");
+    assert!(diagnostic.is_empty());
+}
+
+#[tokio::test]
+async fn cross_major_version_drift_warns_but_still_launches() {
+    let (temp, registry, http, project, name) = remote_fixture("5.0.0");
+    let instances = InstanceRegistry::with_roots(
+        temp.path().join("instances/system"),
+        temp.path().join("instances/user"),
+    );
+    let mut diagnostic = Vec::new();
+    let launch = prepare_wrangler_launch(
+        Some(&name),
+        None,
+        None,
+        Some(&project),
+        &[OsString::from("deploy")],
+        temp.path(),
+        &instances,
+        &registry,
+        &http,
+        None,
+        &mut diagnostic,
+    )
+    .await
+    .unwrap();
+    assert_eq!(launch.wrangler_version, "5.0.0");
+    assert_eq!(launch.certified_wrangler_version, "4.127.1");
+    let diagnostic = String::from_utf8(diagnostic).unwrap();
+    assert!(diagnostic.contains("WRANGLER_MAJOR_VERSION_MISMATCH"));
+    assert!(diagnostic.contains(&format!("path={}", launch.executable.display())));
+    assert!(diagnostic.contains("detected=5.0.0 certified=4.127.1"));
+    assert!(!diagnostic.contains("test-deployer-token"));
+}
+
+#[tokio::test]
+async fn failed_version_process_remains_a_hard_failure() {
+    let (temp, registry, http, project, name) = remote_fixture("4.127.1");
+    let executable = temp.path().join("workspace/node_modules/.bin/wrangler");
+    fs::write(&executable, "#!/bin/sh\nexit 23\n").unwrap();
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
     let instances = InstanceRegistry::with_roots(
         temp.path().join("instances/system"),
         temp.path().join("instances/user"),
@@ -237,15 +301,14 @@ async fn wrong_version_fails_before_launch_with_secret_free_diagnostics() {
     .await
     .unwrap_err();
     assert_eq!(error.code(), ErrorCode::WranglerInvalid);
-    let diagnostic = String::from_utf8(diagnostic).unwrap();
-    assert!(diagnostic.contains("detected=4.126.0 expected=4.127.1"));
-    assert!(!diagnostic.contains("test-deployer-token"));
+    assert!(diagnostic.is_empty());
 }
 
 #[tokio::test]
-async fn missing_binary_empty_arguments_and_selector_conflicts_fail_closed() {
+async fn unusable_binary_empty_arguments_and_selector_conflicts_fail_closed() {
     let (temp, registry, http, project, name) = remote_fixture("4.127.1");
-    fs::remove_file(temp.path().join("workspace/node_modules/.bin/wrangler")).unwrap();
+    let executable = temp.path().join("workspace/node_modules/.bin/wrangler");
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o600)).unwrap();
     let instances = InstanceRegistry::with_roots(
         temp.path().join("instances/system"),
         temp.path().join("instances/user"),

--- a/crates/service/tests/p12_wrangler_workflow.rs
+++ b/crates/service/tests/p12_wrangler_workflow.rs
@@ -73,13 +73,18 @@ fn serve_target(requests: usize) -> (String, thread::JoinHandle<()>) {
     (format!("http://{address}/client/v4"), handle)
 }
 
-fn write_fake_wrangler(project: &Path, api_base_url: &str, started: &Path) -> PathBuf {
+fn write_fake_wrangler(
+    project: &Path,
+    api_base_url: &str,
+    started: &Path,
+    version: &str,
+) -> PathBuf {
     let bin = project.join("node_modules/.bin/wrangler");
     fs::create_dir_all(bin.parent().unwrap()).unwrap();
     let script = format!(
         r#"#!/bin/sh
 if [ "$1" = "--version" ]; then
-  printf '4.127.1\n'
+  printf '{version}\n'
   exit 0
 fi
 [ "$CLOUDFLARE_API_BASE_URL" = "{api_base_url}" ] || exit 81
@@ -122,7 +127,7 @@ fn target_commands_and_wrangler_wrapper_preserve_the_day1_boundary() {
     let token = temp.path().join("deployer.token");
     fs::write(&token, "fixture-deployer-token\n").unwrap();
     fs::set_permissions(&token, fs::Permissions::from_mode(0o600)).unwrap();
-    let (api_base_url, server) = serve_target(4);
+    let (api_base_url, server) = serve_target(5);
 
     let add = run(ocd(&config_home)
         .args(["target", "add", "remote", "--api-base-url"])
@@ -151,7 +156,7 @@ fn target_commands_and_wrangler_wrapper_preserve_the_day1_boundary() {
     let project = temp.path().join("project");
     fs::create_dir(&project).unwrap();
     let started = temp.path().join("wrangler-started");
-    write_fake_wrangler(&project, &api_base_url, &started);
+    write_fake_wrangler(&project, &api_base_url, &started, "4.127.1");
     let wrapped = run(ocd(&config_home)
         .env("CLOUDFLARE_API_KEY", "legacy-key")
         .env("CLOUDFLARE_EMAIL", "legacy@example.invalid")
@@ -165,6 +170,18 @@ fn target_commands_and_wrangler_wrapper_preserve_the_day1_boundary() {
     let wrapped_stderr = String::from_utf8(wrapped.stderr).unwrap();
     assert!(wrapped_stderr.contains("WRANGLER_TARGET kind=target name=remote"));
     assert!(!wrapped_stderr.contains("fixture-deployer-token"));
+
+    write_fake_wrangler(&project, &api_base_url, &started, "5.0.0");
+    let cross_major = run(ocd(&config_home)
+        .args(["wrangler", "--target", "remote", "--project"])
+        .arg(&project)
+        .args(["deploy", "--config", "配置.jsonc", "", "--cwd", "nested"]));
+    assert_eq!(cross_major.status.code(), Some(37));
+    let cross_major_stderr = String::from_utf8(cross_major.stderr).unwrap();
+    assert!(cross_major_stderr.contains("WRANGLER_MAJOR_VERSION_MISMATCH"));
+    assert!(cross_major_stderr.contains("detected=5.0.0 certified=4.127.1"));
+    assert!(cross_major_stderr.contains("certified_wrangler=4.127.1"));
+    assert!(!cross_major_stderr.contains("fixture-deployer-token"));
 
     let terminated = ocd(&config_home)
         .args(["wrangler", "--target", "remote", "--project"])

--- a/docs/p13-documentation-site-restructure.md
+++ b/docs/p13-documentation-site-restructure.md
@@ -86,7 +86,7 @@ P13 重写后的站点必须把以下行为写成当前产品事实：
 - `--instance` 与 `--config` 互斥，显式 ID/路径优先，0/1/N 运行实例按 P11 返回确定结果；
 - `ocd dashboard` 使用一次性 login code 打开正确实例，不让用户复制长期 admin token；
 - 每条有效 CLI 命令执行前使用冷却缓存完成非阻塞升级提醒，daemon startup 保持离线；
-- Worker 项目只使用标准 `wrangler.jsonc` 和项目内精确版本 Wrangler；
+- Worker 项目只使用标准 `wrangler.jsonc` 和项目内可复现固定的 Wrangler；launcher 只比较认证 major，跨 major warning 不阻塞；
 - `wrangler dev` 是快速本地循环，`ocd wrangler` 是面向真实 open-compute target 的安全 launcher；
 - `ocd wrangler deploy --env dev` 不要求多余的 `--`；从 Wrangler command 开始的 argv 原样透传；
 - `ocd wrangler --project <dir> ...` 可从任意目录选择项目；
@@ -521,7 +521,7 @@ P13 不建立第二套产品事实数据库。authority 固定为：
 - CLI 覆盖 P11/P12 全命令、selector、联网/变更属性、JSON/exit status；
 - Operate 覆盖 install/setup/config/service/instances/dashboard/network/storage/health/upgrade/backup/incidents；
 - public docs 中 `oc` 旧命令、旧配置名和相互矛盾的安装流程为零；
-- 所有 Wrangler version 文本与 authority pin 一致；
+- 所有 Wrangler version 文本把 authority 精确版本表述为认证基线，并准确说明 launcher 的 major-only warning 行为；
 - 所有 advertised capability 能映射到 capabilities/compatibility authority，后续 P14/P15 不被误写为 available；
 - 英文/中文路径、导航层级和关键命令语义完全对称；
 - 现有 public product URL 可访问，迁移 URL 只经过一次 301 到有效目标；

--- a/packages/docs/ocd/cli.md
+++ b/packages/docs/ocd/cli.md
@@ -48,7 +48,7 @@ Only `test` makes a network request and opens the token file. Remove keeps the e
 
 ## `wrangler`
 
-Select an open-compute authority, verify its capability-advertised exact Wrangler pin, and replace `ocd` with the nearest project-local Wrangler. Arguments beginning with the Wrangler command are passed unchanged.
+Select an open-compute authority, read its capability-advertised certified Wrangler version, and replace `ocd` with the nearest project-local Wrangler. Minor and patch drift is accepted silently; a major mismatch warns without blocking the child command. Arguments beginning with the Wrangler command are passed unchanged.
 
 ```sh
 ocd wrangler deploy --env dev

--- a/packages/docs/workers/projects.md
+++ b/packages/docs/workers/projects.md
@@ -1,6 +1,6 @@
 # Wrangler projects and deployment targets
 
-Keep a Worker as a standard Wrangler project. The project owns `wrangler.jsonc`, its exact `wrangler` dependency and lockfile, source, environments, local `.dev.vars`, and tests. `ocd` owns the selected open-compute authority and injects its short-lived deployer credential only into the Wrangler child process.
+Keep a Worker as a standard Wrangler project. The project owns `wrangler.jsonc`, its reproducibly pinned `wrangler` dependency and lockfile, source, environments, local `.dev.vars`, and tests. `ocd` owns the selected open-compute authority and injects its short-lived deployer credential only into the Wrangler child process.
 
 ## Three separate selectors
 
@@ -49,11 +49,11 @@ ocd target show company-prod --json
 ocd target remove company-prod
 ```
 
-List, show, and remove do not open the token file. Remove leaves that external file in place. `target test` is the explicit network operation: it verifies authentication, the account, capabilities, and the certified exact Wrangler version.
+List, show, and remove do not open the token file. Remove leaves that external file in place. `target test` is the explicit network operation: it verifies authentication, the account, capabilities, and the exact Wrangler version used as the certified baseline.
 
 ## Project-local Wrangler
 
-Pin Wrangler exactly in `devDependencies` and commit the Bun lockfile. The launcher walks upward from `--project` (or the startup directory) and executes the nearest `node_modules/.bin/wrangler`. It refuses a missing binary or a version that differs from the selected target's capability pin; it never downloads or repairs a dependency.
+Pin Wrangler reproducibly in `devDependencies` and commit the Bun lockfile. The launcher walks upward from `--project` (or the startup directory) and executes the nearest `node_modules/.bin/wrangler`. It accepts minor and patch drift within the target's certified major version without a warning. A different major version emits a warning with the detected and certified versions but still launches Wrangler; the child command owns the final exit status. The launcher still refuses a missing binary or a failed version check, and it never downloads or repairs a dependency.
 
 Everything after the Wrangler command is opaque:
 
@@ -109,7 +109,7 @@ The repository example includes [GitHub Actions](https://github.com/elliothux/op
 | Target not found          | Run `ocd target list`; target names are exact                                                                                                            |
 | Token file rejected       | Use an absolute regular file owned by the current user with exact mode `0600`; do not use a symlink                                                      |
 | Capability probe fails    | Run `ocd target test <name>` and verify network/TLS, account, and deployer role                                                                          |
-| Wrangler version mismatch | Install the exact reported version in the project and update the lockfile intentionally                                                                  |
+| Wrangler major mismatch   | Review the detected and certified versions in the warning; use the certified major when compatibility matters                                           |
 | Wrangler command fails    | Keep its exit status and Cloudflare-style error; fix the project or supported capability rather than removing bindings or retrying with rewritten config |
 
 Wrangler's standard environment variable and environment behavior remain upstream contracts: [system environment variables](https://developers.cloudflare.com/workers/wrangler/system-environment-variables/) and [environments](https://developers.cloudflare.com/workers/wrangler/environments/).

--- a/packages/docs/zh/ocd/cli.md
+++ b/packages/docs/zh/ocd/cli.md
@@ -48,7 +48,7 @@ ocd target remove company-prod
 
 ## `wrangler`
 
-选择 open-compute authority，核对 capability 公布的 Wrangler 精确 pin，然后用最近的项目内 Wrangler 替换 `ocd`。从 Wrangler command 开始的参数原样传递。
+选择 open-compute authority，读取 capability 公布的 Wrangler 认证版本，然后用最近的项目内 Wrangler 替换 `ocd`。minor、patch 漂移会静默接受；major 不匹配只 warning，不阻塞 child command。从 Wrangler command 开始的参数原样传递。
 
 ```sh
 ocd wrangler deploy --env dev

--- a/packages/docs/zh/workers/projects.md
+++ b/packages/docs/zh/workers/projects.md
@@ -1,6 +1,6 @@
 # Wrangler 项目与部署目标
 
-Worker 保持为标准 Wrangler 项目。项目拥有 `wrangler.jsonc`、精确版本的 `wrangler` 依赖与 lockfile、源码、environment、本地 `.dev.vars` 和测试。`ocd` 只拥有所选 open-compute authority，并且只把短命 deployer credential 注入 Wrangler child process。
+Worker 保持为标准 Wrangler 项目。项目拥有 `wrangler.jsonc`、可复现固定的 `wrangler` 依赖与 lockfile、源码、environment、本地 `.dev.vars` 和测试。`ocd` 只拥有所选 open-compute authority，并且只把短命 deployer credential 注入 Wrangler child process。
 
 ## 三种相互独立的选择
 
@@ -49,11 +49,11 @@ ocd target show company-prod --json
 ocd target remove company-prod
 ```
 
-list、show、remove 都不打开 token file；remove 也不删除外部文件。`target test` 才是显式网络操作：它验证认证、account、capabilities 和服务端认证的 Wrangler 精确版本。
+list、show、remove 都不打开 token file；remove 也不删除外部文件。`target test` 才是显式网络操作：它验证认证、account、capabilities 和作为认证基线的 Wrangler 精确版本。
 
 ## 项目内 Wrangler
 
-在 `devDependencies` 固定 Wrangler 精确版本并提交 Bun lockfile。launcher 从 `--project`（或启动 cwd）向上寻找最近的 `node_modules/.bin/wrangler`。缺少 binary 或版本不等于所选 target 的 capability pin 时直接失败，不下载也不自动修复依赖。
+在 `devDependencies` 中可复现地固定 Wrangler 并提交 Bun lockfile。launcher 从 `--project`（或启动 cwd）向上寻找最近的 `node_modules/.bin/wrangler`。同一认证 major 内的 minor、patch 漂移不会产生 warning；major 不同时会显示 detected 与 certified version，但仍然启动 Wrangler，最终 exit status 由 child command 决定。缺少 binary 或 version check 失败仍然直接失败；launcher 不下载也不自动修复依赖。
 
 Wrangler command 之后的参数保持 opaque：
 
@@ -109,7 +109,7 @@ bun run deploy:ci
 | target 不存在         | 运行 `ocd target list`；target name 精确匹配                                                           |
 | token file 被拒绝     | 使用当前用户拥有、绝对路径、权限精确 `0600` 的 regular file；不要用 symlink                            |
 | capability probe 失败 | 运行 `ocd target test <name>`，检查网络/TLS、account 与 deployer role                                  |
-| Wrangler 版本不匹配   | 在项目中安装错误信息要求的精确版本，并有意更新 lockfile                                                |
+| Wrangler major 不匹配 | 检查 warning 中的 detected 与 certified version；需要兼容保证时使用 certified major                    |
 | Wrangler command 失败 | 保留其 exit status 与 Cloudflare-style error；修正项目或支持能力，不删除 binding、不改写 config 后重试 |
 
 Wrangler 标准环境变量和 environment 行为仍以上游合同为准：[system environment variables](https://developers.cloudflare.com/workers/wrangler/system-environment-variables/) 与 [environments](https://developers.cloudflare.com/workers/wrangler/environments/)。

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "c0c55c3c2c458d921310d25e8f1889ae6cd3d30d68c3bdb18ffab557af2464b2",
+  "openComputeRevision": "8dd00266b43ce39ce95392cd44b9c749f277ebff132b167c12786dd699dbf8b5",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
Closes #37.

## Summary

- compare only the detected and certified Wrangler major versions
- accept minor and patch drift without diagnostics
- warn on cross-major drift while still executing Wrangler and preserving its exit status
- retain both detected and exact certified versions in launch diagnostics
- keep missing/unusable executables and failed version checks as hard failures
- update the English and Chinese operator documentation

## Validation

- bun run build
- cargo fmt --all --check
- ./test/check-rust-clippy.sh
- RUSTFLAGS=-D warnings cargo check --workspace --no-default-features
- cargo +1.98.0 check --workspace --all-targets
- cargo metadata --no-deps --format-version 1
- ./test/check-boundaries.sh
- focused Wrangler launcher and process tests
- ./test/coverage.sh: passed, 90.02% workspace line coverage; its single-round workspace Gate passed

The final uninstrumented workspace Gate passed the changed p12-wrangler target, but later failed in the unrelated p6-wrangler-resources worker-loader tail test with DO_STORAGE_LIMIT. Failure evidence was preserved locally; the same target passed in the immediately preceding coverage Gate.