### PR TITLE
feat: redesign AI provider profiles

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -12,8 +12,9 @@ use url::Url;
 mod ai;
 mod scheduler;
 pub use ai::{
-    AiAuthConfig, AiConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiGenerationCapability,
-    AiGenerationModelConfig, AiProviderConfig, AiTokenizer, AiTokenizerArtifactConfig,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiConfig, AiEmbeddingMetric,
+    AiEmbeddingModelConfig, AiEmbeddingProfileConfig, AiGenerationCapability,
+    AiGenerationModelConfig, AiTokenizer, AiTokenizerArtifactConfig, AiTokenizerConfig,
     ResolvedEmbeddingModelContract, ResolvedTokenizerContract,
 };
 pub use scheduler::{SchedulerConfig, SchedulerPoolConfig, SchedulerPoolsConfig};

--- a/crates/core/src/config/ai.rs
+++ b/crates/core/src/config/ai.rs
@@ -1,20 +1,22 @@
-//! Operator-owned AI provider and immutable model-catalog configuration.
+//! Operator-owned AI backends, model mappings, and immutable embedding profiles.
 
-use super::SecretReference;
+mod backend;
+
 use crate::{ErrorCode, PlatformError};
+pub use backend::{AiAuthConfig, AiBackendConfig, AiBackendProtocol};
+use backend::{canonical_endpoint, headers_digest};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::IpAddr;
 use std::path::{Component, Path, PathBuf};
-use url::Url;
 
-const PROVIDER_ADAPTER: &str = "openai_v1";
-const MAX_PROVIDER_NAME_BYTES: usize = 64;
+const MAX_BACKEND_NAME_BYTES: usize = 64;
 const MAX_MODEL_NAME_BYTES: usize = 256;
 const MAX_REVISION_BYTES: usize = 256;
+const MAX_VECTOR_DIMENSIONS: u32 = 1_536;
+const MAX_MODEL_TOKENS: u32 = 4_000_000;
 
-/// Operator-owned AI providers, model aliases, and bounded client limits.
+/// Operator-owned AI backends, model aliases, profiles, and bounded client limits.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AiConfig {
@@ -34,9 +36,11 @@ pub struct AiConfig {
     pub provider_timeout_ms: u64,
     /// End-to-end query deadline in milliseconds.
     pub query_timeout_ms: u64,
-    /// Named OpenAI-compatible provider endpoints.
-    pub providers: BTreeMap<String, AiProviderConfig>,
-    /// Cloudflare public embedding alias to frozen operator model mapping.
+    /// Named operation-specific OpenAI-compatible backends.
+    pub backends: BTreeMap<String, AiBackendConfig>,
+    /// Named embedding behavior and tokenizer profiles.
+    pub embedding_profiles: BTreeMap<String, AiEmbeddingProfileConfig>,
+    /// Cloudflare public embedding alias to operator model mapping.
     pub embedding_models: BTreeMap<String, AiEmbeddingModelConfig>,
     /// Cloudflare public generation/rewrite/rerank alias to operator mapping.
     pub generation_models: BTreeMap<String, AiGenerationModelConfig>,
@@ -53,7 +57,8 @@ impl Default for AiConfig {
             max_embedding_response_bytes: 16 * 1024 * 1024,
             provider_timeout_ms: 30_000,
             query_timeout_ms: 15_000,
-            providers: BTreeMap::new(),
+            backends: BTreeMap::new(),
+            embedding_profiles: BTreeMap::new(),
             embedding_models: BTreeMap::new(),
             generation_models: BTreeMap::new(),
         }
@@ -62,19 +67,22 @@ impl Default for AiConfig {
 
 impl AiConfig {
     pub(super) fn resolve_paths(&mut self, base: &Path) -> Result<(), PlatformError> {
-        for provider in self.providers.values_mut() {
-            if let AiAuthConfig::Bearer { secret } = &mut provider.auth {
-                super::resolve_secret_path(base, secret)?;
+        for backend in self.backends.values_mut() {
+            match &mut backend.auth {
+                AiAuthConfig::Bearer { secret } | AiAuthConfig::Header { secret, .. } => {
+                    super::resolve_secret_path(base, secret)?;
+                }
+                AiAuthConfig::None => {}
             }
         }
-        for model in self.embedding_models.values_mut() {
-            model.tokenizer_artifact.path =
-                super::resolve_host_path(base, &model.tokenizer_artifact.path)?;
+        for profile in self.embedding_profiles.values_mut() {
+            profile.tokenizer.artifact.path =
+                super::resolve_host_path(base, &profile.tokenizer.artifact.path)?;
         }
         Ok(())
     }
 
-    /// Validate the complete declared catalog without resolving secret values or using the network.
+    /// Validate the complete declared catalog without resolving secrets or using the network.
     pub fn validate(&self) -> Result<(), PlatformError> {
         if self.max_provider_in_flight == 0
             || self.max_provider_in_flight > 256
@@ -97,17 +105,21 @@ impl AiConfig {
                 "ai.query_timeout_ms must not exceed ai.provider_timeout_ms",
             ));
         }
-        for (name, provider) in &self.providers {
-            validate_name(name, MAX_PROVIDER_NAME_BYTES, "AI provider name is invalid")?;
-            provider.validate()?;
+        for (name, backend) in &self.backends {
+            validate_name(name, MAX_BACKEND_NAME_BYTES, "AI backend name is invalid")?;
+            backend.validate()?;
+        }
+        for (name, profile) in &self.embedding_profiles {
+            validate_model_alias(name)?;
+            profile.validate()?;
         }
         for (alias, model) in &self.embedding_models {
             validate_model_alias(alias)?;
-            model.validate(alias, &self.providers)?;
+            model.validate(&self.backends, &self.embedding_profiles)?;
         }
         for (alias, model) in &self.generation_models {
             validate_model_alias(alias)?;
-            model.validate(&self.providers)?;
+            model.validate(&self.backends)?;
         }
         if let Some(default) = &self.default_embedding_model
             && !self.embedding_models.contains_key(default)
@@ -134,50 +146,52 @@ impl AiConfig {
         alias: Option<&str>,
     ) -> Result<ResolvedEmbeddingModelContract, PlatformError> {
         self.validate()?;
-        let alias = match alias {
-            Some(alias) => alias,
-            None => self.default_embedding_model.as_deref().ok_or_else(|| {
-                PlatformError::new(
-                    ErrorCode::ConfigInvalid,
-                    "AI Search requires an explicit or operator-default embedding model",
-                )
-            })?,
-        };
-        let model = self.embedding_models.get(alias).ok_or_else(|| {
-            PlatformError::new(
-                ErrorCode::ConfigInvalid,
-                "embedding model alias is not in the operator catalog",
-            )
-        })?;
-        let provider = self.providers.get(&model.provider).ok_or_else(|| {
-            PlatformError::new(ErrorCode::ConfigInvalid, "embedding provider is missing")
-        })?;
-        let base = canonical_base_url(&provider.base_url)?;
-        let mut endpoint = base.clone();
-        endpoint.set_path("/v1/embeddings");
-        let auth_kind = provider.auth.kind_token();
-        let provider_contract_sha256 = digest_canonical(&ProviderContractDigest {
-            adapter: PROVIDER_ADAPTER,
-            base_url: base.as_str(),
+        let alias = self.embedding_alias(alias)?;
+        let model = self
+            .embedding_models
+            .get(alias)
+            .ok_or_else(missing_embedding_model)?;
+        let backend = self
+            .backends
+            .get(&model.backend)
+            .filter(|backend| backend.protocol == AiBackendProtocol::OpenAiEmbeddingsV1)
+            .ok_or_else(missing_embedding_backend)?;
+        let profile = self
+            .embedding_profiles
+            .get(&model.profile)
+            .ok_or_else(missing_embedding_profile)?;
+        let endpoint = canonical_endpoint(&backend.endpoint)?;
+        let headers_sha256 = headers_digest(&backend.headers)?;
+        let auth_kind = backend.auth.kind_token();
+        let auth_header_name = backend.auth.header_name();
+        let backend_contract_sha256 = digest_canonical(&BackendContractDigest {
+            protocol: backend.protocol.as_str(),
+            endpoint: endpoint.as_str(),
             auth_kind,
+            auth_header_name: auth_header_name.as_deref(),
+            headers_sha256: &headers_sha256,
         })?;
-        let endpoint_sha256 = hex::encode(Sha256::digest(endpoint.as_str().as_bytes()));
+        let profile_contract_sha256 = profile.contract_sha256()?;
         let mut contract = ResolvedEmbeddingModelContract {
             embedding_alias: alias.to_owned(),
-            provider_name: model.provider.clone(),
-            provider_contract_sha256,
-            protocol: "openai_v1_embeddings".to_owned(),
-            endpoint_sha256,
+            backend_name: model.backend.clone(),
+            backend_contract_sha256,
+            protocol: backend.protocol.as_str().to_owned(),
+            endpoint_sha256: hex::encode(Sha256::digest(endpoint.as_str().as_bytes())),
             auth_kind: auth_kind.to_owned(),
+            auth_header_name,
+            headers_sha256,
             remote_model: model.remote_model.clone(),
-            model_revision: model.model_revision.clone(),
-            dimensions: model.dimensions,
-            request_dimensions: model.request_dimensions,
-            metric: model.metric,
-            max_input_tokens: model.max_input_tokens,
-            tokenizer: model.tokenizer,
-            tokenizer_revision: model.tokenizer_revision.clone(),
-            tokenizer_artifact_sha256: model.tokenizer_artifact.sha256.clone(),
+            provider_revision: model.provider_revision.clone(),
+            profile: model.profile.clone(),
+            profile_contract_sha256,
+            dimensions: profile.dimensions,
+            send_dimensions: profile.send_dimensions,
+            metric: AiEmbeddingMetric::Cosine,
+            max_input_tokens: profile.max_input_tokens,
+            tokenizer: profile.tokenizer.kind,
+            tokenizer_revision: profile.tokenizer.revision.clone(),
+            tokenizer_artifact_sha256: profile.tokenizer.artifact.sha256.clone(),
             contract_sha256: String::new(),
         };
         contract.contract_sha256 = digest_canonical(&contract)?;
@@ -191,152 +205,123 @@ impl AiConfig {
         alias: Option<&str>,
     ) -> Result<ResolvedTokenizerContract, PlatformError> {
         self.validate()?;
-        let alias = match alias {
-            Some(alias) => alias,
-            None => self.default_embedding_model.as_deref().ok_or_else(|| {
-                PlatformError::new(
-                    ErrorCode::ConfigInvalid,
-                    "AI Search requires an operator-default tokenizer model",
-                )
-            })?,
-        };
-        let model = self.embedding_models.get(alias).ok_or_else(|| {
-            PlatformError::new(
-                ErrorCode::ConfigInvalid,
-                "tokenizer model alias is not in the operator catalog",
-            )
-        })?;
+        let alias = self.embedding_alias(alias)?;
+        let model = self
+            .embedding_models
+            .get(alias)
+            .ok_or_else(missing_embedding_model)?;
+        let profile = self
+            .embedding_profiles
+            .get(&model.profile)
+            .ok_or_else(missing_embedding_profile)?;
         let mut contract = ResolvedTokenizerContract {
             embedding_alias: alias.to_owned(),
-            tokenizer: model.tokenizer,
-            tokenizer_revision: model.tokenizer_revision.clone(),
-            tokenizer_artifact_sha256: model.tokenizer_artifact.sha256.clone(),
-            max_input_tokens: model.max_input_tokens,
+            profile: model.profile.clone(),
+            profile_contract_sha256: profile.contract_sha256()?,
+            tokenizer: profile.tokenizer.kind,
+            tokenizer_revision: profile.tokenizer.revision.clone(),
+            tokenizer_artifact_sha256: profile.tokenizer.artifact.sha256.clone(),
+            max_input_tokens: profile.max_input_tokens,
             contract_sha256: String::new(),
         };
         contract.contract_sha256 = digest_canonical(&contract)?;
         Ok(contract)
     }
-}
 
-/// One fixed OpenAI-compatible provider endpoint.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct AiProviderConfig {
-    /// Canonical `/v1` root; the platform appends fixed route names.
-    pub base_url: String,
-    /// Explicit authentication policy.
-    pub auth: AiAuthConfig,
-}
-
-impl AiProviderConfig {
-    fn validate(&self) -> Result<(), PlatformError> {
-        let url = canonical_base_url(&self.base_url)?;
-        match &self.auth {
-            AiAuthConfig::Bearer { secret } => secret.validate("ai.providers.*.auth.secret")?,
-            AiAuthConfig::None => {
-                if url.scheme() != "http" || !url_host_is_loopback(&url) {
-                    return Err(PlatformError::new(
-                        ErrorCode::ConfigInvalid,
-                        "AI provider auth kind none is allowed only for loopback HTTP",
-                    ));
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Explicit provider authentication policy.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
-pub enum AiAuthConfig {
-    /// Send one resolved secret as an HTTP Bearer credential.
-    Bearer {
-        /// Symbolic secret reference; its value never enters config serialization or model contracts.
-        secret: SecretReference,
-    },
-    /// Send no credential; accepted only for explicit loopback HTTP.
-    None,
-}
-
-impl AiAuthConfig {
-    /// Stable secret-free token included in the provider contract.
-    #[must_use]
-    pub fn kind_token(&self) -> &'static str {
-        match self {
-            Self::Bearer { .. } => "bearer",
-            Self::None => "none",
+    fn embedding_alias<'a>(&'a self, alias: Option<&'a str>) -> Result<&'a str, PlatformError> {
+        match alias {
+            Some(alias) => Ok(alias),
+            None => self.default_embedding_model.as_deref().ok_or_else(|| {
+                PlatformError::new(
+                    ErrorCode::ConfigInvalid,
+                    "AI Search requires an explicit or operator-default embedding model",
+                )
+            }),
         }
     }
 }
 
-/// Frozen operator mapping for one current Cloudflare embedding alias.
+/// Frozen operator mapping from a public embedding alias to a backend model and profile.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AiEmbeddingModelConfig {
-    /// Provider entry name.
-    pub provider: String,
+    /// Operation-specific backend entry name.
+    pub backend: String,
     /// Model value sent to the provider.
     pub remote_model: String,
-    /// Operator-pinned model revision identity.
-    pub model_revision: String,
-    /// Exact returned vector dimensions.
-    pub dimensions: u32,
-    /// Optional dimensions parameter sent to providers that support it.
-    pub request_dimensions: Option<u32>,
-    /// Frozen similarity metric.
-    pub metric: AiEmbeddingMetric,
-    /// Maximum public input tokens.
-    pub max_input_tokens: u32,
-    /// Known tokenizer family used by chunking.
-    pub tokenizer: AiTokenizer,
-    /// Operator-pinned tokenizer revision identity.
-    pub tokenizer_revision: String,
-    /// Exact offline Hugging Face tokenizer artifact.
-    pub tokenizer_artifact: AiTokenizerArtifactConfig,
+    /// Optional immutable revision identifier actually supported by the provider.
+    #[serde(default)]
+    pub provider_revision: Option<String>,
+    /// Embedding profile entry name.
+    pub profile: String,
 }
 
 impl AiEmbeddingModelConfig {
     fn validate(
         &self,
-        alias: &str,
-        providers: &BTreeMap<String, AiProviderConfig>,
+        backends: &BTreeMap<String, AiBackendConfig>,
+        profiles: &BTreeMap<String, AiEmbeddingProfileConfig>,
     ) -> Result<(), PlatformError> {
-        if !providers.contains_key(&self.provider) {
-            return Err(PlatformError::new(
-                ErrorCode::ConfigInvalid,
-                "AI embedding model references an unknown provider",
-            ));
-        }
-        validate_nonempty(&self.remote_model, MAX_MODEL_NAME_BYTES)?;
-        validate_nonempty(&self.model_revision, MAX_REVISION_BYTES)?;
-        validate_nonempty(&self.tokenizer_revision, MAX_REVISION_BYTES)?;
-        self.tokenizer_artifact.validate()?;
-        let (dimensions, max_input_tokens) =
-            cloudflare_embedding_contract(alias).ok_or_else(|| {
-                PlatformError::new(
-                    ErrorCode::ConfigInvalid,
-                    "AI embedding alias is outside the pinned Cloudflare model catalog",
-                )
-            })?;
-        if self.dimensions != dimensions
-            || self.max_input_tokens != max_input_tokens
-            || self.metric != AiEmbeddingMetric::Cosine
-            || self
-                .request_dimensions
-                .is_some_and(|value| value != self.dimensions)
+        if !backends
+            .get(&self.backend)
+            .is_some_and(|backend| backend.protocol == AiBackendProtocol::OpenAiEmbeddingsV1)
         {
             return Err(PlatformError::new(
                 ErrorCode::ConfigInvalid,
-                "AI embedding model conflicts with the pinned Cloudflare contract",
+                "AI embedding model references an incompatible backend",
             ));
         }
-        Ok(())
+        if !profiles.contains_key(&self.profile) {
+            return Err(missing_embedding_profile());
+        }
+        validate_nonempty(&self.remote_model, MAX_MODEL_NAME_BYTES)?;
+        validate_optional_nonempty(self.provider_revision.as_deref(), MAX_REVISION_BYTES)
     }
 }
 
-/// Similarity metric admitted for the pinned AI Search embedding catalog.
+/// Exact vector and tokenizer behavior shared by one or more embedding model mappings.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AiEmbeddingProfileConfig {
+    /// Exact returned vector dimensions.
+    pub dimensions: u32,
+    /// Maximum public input tokens accepted by open-compute.
+    pub max_input_tokens: u32,
+    /// Send the profile dimensions as the `OpenAI` `dimensions` request member.
+    #[serde(default)]
+    pub send_dimensions: bool,
+    /// Exact offline tokenizer contract.
+    pub tokenizer: AiTokenizerConfig,
+}
+
+impl AiEmbeddingProfileConfig {
+    fn validate(&self) -> Result<(), PlatformError> {
+        if self.dimensions == 0
+            || self.dimensions > MAX_VECTOR_DIMENSIONS
+            || self.max_input_tokens == 0
+            || self.max_input_tokens > MAX_MODEL_TOKENS
+        {
+            return Err(PlatformError::new(
+                ErrorCode::ConfigInvalid,
+                "AI embedding profile limits are invalid",
+            ));
+        }
+        self.tokenizer.validate()
+    }
+
+    fn contract_sha256(&self) -> Result<String, PlatformError> {
+        digest_canonical(&ProfileContractDigest {
+            dimensions: self.dimensions,
+            max_input_tokens: self.max_input_tokens,
+            send_dimensions: self.send_dimensions,
+            tokenizer: self.tokenizer.kind,
+            tokenizer_revision: &self.tokenizer.revision,
+            tokenizer_artifact_sha256: &self.tokenizer.artifact.sha256,
+        })
+    }
+}
+
+/// Frozen similarity metric used by AI Search embedding indexes.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AiEmbeddingMetric {
@@ -358,6 +343,27 @@ pub enum AiTokenizer {
     EmbeddingGemma,
     /// Gemini embedding tokenizer.
     Gemini,
+    /// Operator-defined Hugging Face tokenizer JSON without a product family claim.
+    Custom,
+}
+
+/// Exact tokenizer identity and offline artifact used by an embedding profile.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AiTokenizerConfig {
+    /// Known tokenizer family or `custom` for an operator-defined tokenizer.
+    pub kind: AiTokenizer,
+    /// Operator-pinned tokenizer revision identity.
+    pub revision: String,
+    /// Exact offline Hugging Face tokenizer artifact.
+    pub artifact: AiTokenizerArtifactConfig,
+}
+
+impl AiTokenizerConfig {
+    fn validate(&self) -> Result<(), PlatformError> {
+        validate_nonempty(&self.revision, MAX_REVISION_BYTES)?;
+        self.artifact.validate()
+    }
 }
 
 /// Operator-pinned offline Hugging Face `tokenizer.json` artifact.
@@ -396,12 +402,13 @@ impl AiTokenizerArtifactConfig {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AiGenerationModelConfig {
-    /// Provider entry name.
-    pub provider: String,
+    /// Operation-specific backend entry name.
+    pub backend: String,
     /// Model value sent to the provider.
     pub remote_model: String,
-    /// Operator-pinned model revision identity.
-    pub model_revision: String,
+    /// Optional immutable revision identifier actually supported by the provider.
+    #[serde(default)]
+    pub provider_revision: Option<String>,
     /// Maximum context tokens accepted by the adapter.
     pub max_context_tokens: u32,
     /// Explicit capabilities admitted for this alias.
@@ -409,13 +416,12 @@ pub struct AiGenerationModelConfig {
 }
 
 impl AiGenerationModelConfig {
-    fn validate(
-        &self,
-        providers: &BTreeMap<String, AiProviderConfig>,
-    ) -> Result<(), PlatformError> {
-        if !providers.contains_key(&self.provider)
+    fn validate(&self, backends: &BTreeMap<String, AiBackendConfig>) -> Result<(), PlatformError> {
+        if !backends
+            .get(&self.backend)
+            .is_some_and(|backend| backend.protocol == AiBackendProtocol::OpenAiChatCompletionsV1)
             || self.max_context_tokens == 0
-            || self.max_context_tokens > 4_000_000
+            || self.max_context_tokens > MAX_MODEL_TOKENS
             || self.capabilities.is_empty()
         {
             return Err(PlatformError::new(
@@ -424,11 +430,11 @@ impl AiGenerationModelConfig {
             ));
         }
         validate_nonempty(&self.remote_model, MAX_MODEL_NAME_BYTES)?;
-        validate_nonempty(&self.model_revision, MAX_REVISION_BYTES)
+        validate_optional_nonempty(self.provider_revision.as_deref(), MAX_REVISION_BYTES)
     }
 }
 
-/// Explicit provider operations implemented for a generation model alias.
+/// Explicit backend operations implemented for a generation model alias.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AiGenerationCapability {
@@ -446,24 +452,32 @@ pub enum AiGenerationCapability {
 pub struct ResolvedEmbeddingModelContract {
     /// Tenant-visible Cloudflare model alias.
     pub embedding_alias: String,
-    /// Operator provider entry name.
-    pub provider_name: String,
-    /// Digest of adapter, canonical base URL, and auth kind.
-    pub provider_contract_sha256: String,
-    /// Fixed provider protocol token.
+    /// Operator backend entry name.
+    pub backend_name: String,
+    /// Digest of backend protocol, endpoint, auth shape, and static headers.
+    pub backend_contract_sha256: String,
+    /// Fixed backend protocol token.
     pub protocol: String,
-    /// Digest of the canonical embeddings endpoint URL.
+    /// Digest of the canonical final endpoint URL.
     pub endpoint_sha256: String,
     /// Secret-free authentication kind.
     pub auth_kind: String,
+    /// Normalized custom authentication header name, when used.
+    pub auth_header_name: Option<String>,
+    /// Digest of normalized static header names and values.
+    pub headers_sha256: String,
     /// Provider model value.
     pub remote_model: String,
-    /// Operator-pinned model revision.
-    pub model_revision: String,
+    /// Optional provider-supported immutable model revision.
+    pub provider_revision: Option<String>,
+    /// Operator embedding profile name.
+    pub profile: String,
+    /// Digest of the expanded embedding profile.
+    pub profile_contract_sha256: String,
     /// Exact vector dimensions.
     pub dimensions: u32,
-    /// Optional requested output dimensions.
-    pub request_dimensions: Option<u32>,
+    /// Whether the dimensions request member is sent.
+    pub send_dimensions: bool,
     /// Frozen similarity metric.
     pub metric: AiEmbeddingMetric,
     /// Maximum input tokens.
@@ -482,48 +496,41 @@ pub struct ResolvedEmbeddingModelContract {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ResolvedTokenizerContract {
-    /// Operator model alias that owns the tokenizer artifact.
+    /// Operator model alias that selects the tokenizer profile.
     pub embedding_alias: String,
+    /// Operator embedding profile name.
+    pub profile: String,
+    /// Digest of the expanded embedding profile.
+    pub profile_contract_sha256: String,
     /// Frozen tokenizer family.
     pub tokenizer: AiTokenizer,
     /// Operator-pinned tokenizer revision.
     pub tokenizer_revision: String,
     /// SHA-256 of the exact offline tokenizer artifact.
     pub tokenizer_artifact_sha256: String,
-    /// Maximum input tokens inherited from the pinned model catalog.
+    /// Maximum input tokens inherited from the profile.
     pub max_input_tokens: u32,
     /// Digest of this complete contract with this field empty.
     pub contract_sha256: String,
 }
 
 #[derive(Serialize)]
-struct ProviderContractDigest<'a> {
-    adapter: &'static str,
-    base_url: &'a str,
+struct BackendContractDigest<'a> {
+    protocol: &'a str,
+    endpoint: &'a str,
     auth_kind: &'a str,
+    auth_header_name: Option<&'a str>,
+    headers_sha256: &'a str,
 }
 
-fn canonical_base_url(value: &str) -> Result<Url, PlatformError> {
-    let url = Url::parse(value).map_err(|_| invalid_provider_url())?;
-    if !matches!(url.scheme(), "http" | "https")
-        || url.host_str().is_none_or(str::is_empty)
-        || !url.username().is_empty()
-        || url.password().is_some()
-        || url.query().is_some()
-        || url.fragment().is_some()
-        || url.path() != "/v1"
-        || value != url.as_str()
-        || (url.scheme() == "http" && !url_host_is_loopback(&url))
-    {
-        return Err(invalid_provider_url());
-    }
-    Ok(url)
-}
-
-fn url_host_is_loopback(url: &Url) -> bool {
-    url.host_str()
-        .and_then(|host| host.parse::<IpAddr>().ok())
-        .is_some_and(|ip| ip.is_loopback())
+#[derive(Serialize)]
+struct ProfileContractDigest<'a> {
+    dimensions: u32,
+    max_input_tokens: u32,
+    send_dimensions: bool,
+    tokenizer: AiTokenizer,
+    tokenizer_revision: &'a str,
+    tokenizer_artifact_sha256: &'a str,
 }
 
 fn validate_model_alias(alias: &str) -> Result<(), PlatformError> {
@@ -536,7 +543,7 @@ fn validate_model_alias(alias: &str) -> Result<(), PlatformError> {
     {
         return Err(PlatformError::new(
             ErrorCode::ConfigInvalid,
-            "AI model alias is invalid",
+            "AI model or profile alias is invalid",
         ));
     }
     Ok(())
@@ -555,6 +562,13 @@ fn validate_name(value: &str, max: usize, message: &'static str) -> Result<(), P
     Ok(())
 }
 
+fn validate_optional_nonempty(value: Option<&str>, max: usize) -> Result<(), PlatformError> {
+    match value {
+        Some(value) => validate_nonempty(value, max),
+        None => Ok(()),
+    }
+}
+
 fn validate_nonempty(value: &str, max: usize) -> Result<(), PlatformError> {
     if value.is_empty()
         || value.len() > max
@@ -569,17 +583,6 @@ fn validate_nonempty(value: &str, max: usize) -> Result<(), PlatformError> {
     Ok(())
 }
 
-fn cloudflare_embedding_contract(alias: &str) -> Option<(u32, u32)> {
-    match alias {
-        "google-ai-studio/gemini-embedding-001" => Some((1536, 2048)),
-        "openai/text-embedding-3-small" | "openai/text-embedding-3-large" => Some((1536, 8192)),
-        "@cf/baai/bge-m3" | "@cf/baai/bge-large-en-v1.5" => Some((1024, 512)),
-        "@cf/qwen/qwen3-embedding-0.6b" => Some((1024, 8192)),
-        "@cf/google/embeddinggemma-300m" => Some((768, 512)),
-        _ => None,
-    }
-}
-
 fn digest_canonical<T: Serialize>(value: &T) -> Result<String, PlatformError> {
     let bytes = serde_json::to_vec(value).map_err(|_| {
         PlatformError::new(
@@ -590,10 +593,24 @@ fn digest_canonical<T: Serialize>(value: &T) -> Result<String, PlatformError> {
     Ok(hex::encode(Sha256::digest(bytes)))
 }
 
-fn invalid_provider_url() -> PlatformError {
+fn missing_embedding_model() -> PlatformError {
     PlatformError::new(
         ErrorCode::ConfigInvalid,
-        "AI provider base_url must be a canonical HTTPS or loopback HTTP /v1/ root",
+        "embedding model alias is not in the operator catalog",
+    )
+}
+
+fn missing_embedding_backend() -> PlatformError {
+    PlatformError::new(
+        ErrorCode::ConfigInvalid,
+        "embedding backend is missing or incompatible",
+    )
+}
+
+fn missing_embedding_profile() -> PlatformError {
+    PlatformError::new(
+        ErrorCode::ConfigInvalid,
+        "embedding profile is not in the operator catalog",
     )
 }
 

--- a/crates/core/src/config/ai/backend.rs
+++ b/crates/core/src/config/ai/backend.rs
@@ -1,0 +1,265 @@
+use super::super::SecretReference;
+use crate::{ErrorCode, PlatformError};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::IpAddr;
+use url::Url;
+
+const MAX_HEADERS: usize = 16;
+const MAX_HEADER_NAME_BYTES: usize = 64;
+const MAX_HEADER_VALUE_BYTES: usize = 4 * 1024;
+const MAX_HEADER_BYTES: usize = 8 * 1024;
+
+/// One operation-specific OpenAI-compatible backend.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AiBackendConfig {
+    /// Closed request and response protocol implemented by this backend.
+    pub protocol: AiBackendProtocol,
+    /// Canonical final request URL; no route is appended at runtime.
+    pub endpoint: String,
+    /// Explicit authentication policy.
+    pub auth: AiAuthConfig,
+    /// Bounded non-sensitive static metadata headers.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+impl AiBackendConfig {
+    pub(super) fn validate(&self) -> Result<(), PlatformError> {
+        let url = canonical_endpoint(&self.endpoint)?;
+        self.auth.validate()?;
+        let auth_header = self.auth.header_name();
+        validate_headers(&self.headers, auth_header.as_deref())?;
+        if self.auth == AiAuthConfig::None
+            && (url.scheme() != "http" || !url_host_is_loopback(&url))
+        {
+            return Err(PlatformError::new(
+                ErrorCode::ConfigInvalid,
+                "AI backend auth kind none is allowed only for loopback HTTP",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Closed OpenAI-compatible operation protocols.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiBackendProtocol {
+    /// OpenAI-compatible embeddings request and response shapes.
+    #[serde(rename = "openai_embeddings_v1")]
+    OpenAiEmbeddingsV1,
+    /// OpenAI-compatible chat-completions and SSE shapes.
+    #[serde(rename = "openai_chat_completions_v1")]
+    OpenAiChatCompletionsV1,
+}
+
+impl AiBackendProtocol {
+    /// Stable token frozen into model contracts.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenAiEmbeddingsV1 => "openai_embeddings_v1",
+            Self::OpenAiChatCompletionsV1 => "openai_chat_completions_v1",
+        }
+    }
+}
+
+/// Explicit backend authentication policy.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AiAuthConfig {
+    /// Send one resolved secret as an HTTP Bearer credential.
+    Bearer {
+        /// Symbolic secret reference; its value never enters config serialization or contracts.
+        secret: SecretReference,
+    },
+    /// Send one resolved secret as the complete value of a custom header.
+    Header {
+        /// Header name; `Authorization` and platform-owned headers are forbidden.
+        name: String,
+        /// Symbolic secret reference; its value never enters config serialization or contracts.
+        secret: SecretReference,
+    },
+    /// Send no credential; accepted only for explicit loopback HTTP.
+    None,
+}
+
+impl AiAuthConfig {
+    fn validate(&self) -> Result<(), PlatformError> {
+        match self {
+            Self::Bearer { secret } => secret.validate("ai.backends.*.auth.secret"),
+            Self::Header { name, secret } => {
+                let normalized = normalize_header_name(name)?;
+                if reserved_header(&normalized) {
+                    return Err(invalid_header());
+                }
+                secret.validate("ai.backends.*.auth.secret")
+            }
+            Self::None => Ok(()),
+        }
+    }
+
+    /// Stable secret-free token included in the backend contract.
+    #[must_use]
+    pub const fn kind_token(&self) -> &'static str {
+        match self {
+            Self::Bearer { .. } => "bearer",
+            Self::Header { .. } => "header",
+            Self::None => "none",
+        }
+    }
+
+    /// Normalized custom credential header name, when configured.
+    #[must_use]
+    pub fn header_name(&self) -> Option<String> {
+        match self {
+            Self::Header { name, .. } => Some(name.to_ascii_lowercase()),
+            Self::Bearer { .. } | Self::None => None,
+        }
+    }
+}
+
+pub(super) fn canonical_endpoint(value: &str) -> Result<Url, PlatformError> {
+    let url = Url::parse(value).map_err(|_| invalid_backend_url())?;
+    let path = url.path();
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none_or(str::is_empty)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || path == "/"
+        || path.ends_with('/')
+        || path.contains("//")
+        || value != url.as_str()
+        || (url.scheme() == "http" && !url_host_is_loopback(&url))
+    {
+        return Err(invalid_backend_url());
+    }
+    Ok(url)
+}
+
+pub(super) fn headers_digest(headers: &BTreeMap<String, String>) -> Result<String, PlatformError> {
+    #[derive(Serialize)]
+    struct Entry<'a> {
+        name: String,
+        value: &'a str,
+    }
+
+    let mut entries = headers
+        .iter()
+        .map(|(name, value)| Entry {
+            name: name.to_ascii_lowercase(),
+            value,
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.name.cmp(&right.name));
+    let bytes = serde_json::to_vec(&entries).map_err(|_| invalid_header())?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+
+fn url_host_is_loopback(url: &Url) -> bool {
+    url.host_str()
+        .and_then(|host| host.parse::<IpAddr>().ok())
+        .is_some_and(|ip| ip.is_loopback())
+}
+
+fn validate_headers(
+    headers: &BTreeMap<String, String>,
+    auth_header_name: Option<&str>,
+) -> Result<(), PlatformError> {
+    if headers.len() > MAX_HEADERS {
+        return Err(invalid_header());
+    }
+    let mut normalized = BTreeSet::new();
+    let mut bytes = 0_usize;
+    for (name, value) in headers {
+        let name = normalize_header_name(name)?;
+        if reserved_header(&name)
+            || auth_header_name == Some(name.as_str())
+            || !normalized.insert(name.clone())
+            || value.is_empty()
+            || value.len() > MAX_HEADER_VALUE_BYTES
+            || value.trim() != value
+            || value.chars().any(char::is_control)
+        {
+            return Err(invalid_header());
+        }
+        bytes = bytes
+            .checked_add(name.len())
+            .and_then(|total| total.checked_add(value.len()))
+            .ok_or_else(invalid_header)?;
+    }
+    if bytes > MAX_HEADER_BYTES {
+        return Err(invalid_header());
+    }
+    Ok(())
+}
+
+fn normalize_header_name(value: &str) -> Result<String, PlatformError> {
+    if value.is_empty()
+        || value.len() > MAX_HEADER_NAME_BYTES
+        || !value.bytes().all(is_header_name_byte)
+    {
+        return Err(invalid_header());
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+const fn is_header_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+fn reserved_header(name: &str) -> bool {
+    matches!(
+        name,
+        "authorization"
+            | "host"
+            | "content-length"
+            | "content-type"
+            | "accept"
+            | "user-agent"
+            | "cookie"
+            | "connection"
+            | "transfer-encoding"
+            | "upgrade"
+            | "te"
+            | "trailer"
+            | "proxy-authorization"
+            | "proxy-authenticate"
+    ) || name.starts_with("proxy-")
+}
+
+fn invalid_backend_url() -> PlatformError {
+    PlatformError::new(
+        ErrorCode::ConfigInvalid,
+        "AI backend endpoint must be a canonical HTTPS or loopback HTTP final URL",
+    )
+}
+
+fn invalid_header() -> PlatformError {
+    PlatformError::new(
+        ErrorCode::ConfigInvalid,
+        "AI backend header contract is invalid",
+    )
+}

--- a/crates/core/src/config/ai/tests.rs
+++ b/crates/core/src/config/ai/tests.rs
@@ -1,74 +1,130 @@
 use super::*;
+use crate::SecretReference;
 
-fn configured() -> AiConfig {
-    let mut config = AiConfig::default();
-    config.providers.insert(
-        "fixture".to_owned(),
-        AiProviderConfig {
-            base_url: "http://127.0.0.1:8080/v1".to_owned(),
-            auth: AiAuthConfig::Bearer {
-                secret: SecretReference {
-                    env: Some("AI_FIXTURE_KEY".to_owned()),
-                    file: None,
-                },
-            },
-        },
-    );
-    config.embedding_models.insert(
-        "@cf/qwen/qwen3-embedding-0.6b".to_owned(),
-        AiEmbeddingModelConfig {
-            provider: "fixture".to_owned(),
-            remote_model: "@cf/qwen/qwen3-embedding-0.6b".to_owned(),
-            model_revision: "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned(),
-            dimensions: 1024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned(),
-            tokenizer_artifact: AiTokenizerArtifactConfig {
+const ALIAS: &str = "@cf/qwen/qwen3-embedding-0.6b";
+const PROFILE: &str = "fixture/qwen3-1024";
+
+fn secret() -> SecretReference {
+    SecretReference {
+        env: Some("AI_FIXTURE_KEY".to_owned()),
+        file: None,
+    }
+}
+
+fn embedding_profile() -> AiEmbeddingProfileConfig {
+    AiEmbeddingProfileConfig {
+        dimensions: 1_024,
+        max_input_tokens: 8_192,
+        send_dimensions: false,
+        tokenizer: AiTokenizerConfig {
+            kind: AiTokenizer::Qwen3,
+            revision: "tokenizer-revision".to_owned(),
+            artifact: AiTokenizerArtifactConfig {
                 path: PathBuf::from("/opt/open-compute/models/qwen3/tokenizer.json"),
                 sha256: "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"
                     .to_owned(),
             },
         },
+    }
+}
+
+fn configured() -> AiConfig {
+    let mut config = AiConfig::default();
+    config.backends.insert(
+        "fixture-embeddings".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: "http://127.0.0.1:8080/compatible-mode/v1/embeddings".to_owned(),
+            auth: AiAuthConfig::Bearer { secret: secret() },
+            headers: BTreeMap::from([("X-Title".to_owned(), "open-compute".to_owned())]),
+        },
     );
-    config.default_embedding_model = Some("@cf/qwen/qwen3-embedding-0.6b".to_owned());
+    config
+        .embedding_profiles
+        .insert(PROFILE.to_owned(), embedding_profile());
+    config.embedding_models.insert(
+        ALIAS.to_owned(),
+        AiEmbeddingModelConfig {
+            backend: "fixture-embeddings".to_owned(),
+            remote_model: "qwen3.7-text-embedding-flash".to_owned(),
+            provider_revision: None,
+            profile: PROFILE.to_owned(),
+        },
+    );
+    config.default_embedding_model = Some(ALIAS.to_owned());
     config
 }
 
+fn add_chat(config: &mut AiConfig) {
+    config.backends.insert(
+        "fixture-chat".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiChatCompletionsV1,
+            endpoint: "http://127.0.0.1:8080/compatible-mode/v1/chat/completions".to_owned(),
+            auth: AiAuthConfig::None,
+            headers: BTreeMap::new(),
+        },
+    );
+    config.generation_models.insert(
+        "fixture/chat".to_owned(),
+        AiGenerationModelConfig {
+            backend: "fixture-chat".to_owned(),
+            remote_model: "fixture-chat".to_owned(),
+            provider_revision: Some("revision-1".to_owned()),
+            max_context_tokens: 8_192,
+            capabilities: [
+                AiGenerationCapability::Chat,
+                AiGenerationCapability::Rewrite,
+            ]
+            .into_iter()
+            .collect(),
+        },
+    );
+}
+
 #[test]
-fn fixture_catalog_resolves_to_stable_secret_free_contract() {
+fn catalog_resolves_prefixed_endpoint_profile_to_stable_secret_free_contract() {
     let config = configured();
     config.validate().unwrap();
     let first = config.resolve_embedding_model(None).unwrap();
-    let second = config
-        .resolve_embedding_model(Some("@cf/qwen/qwen3-embedding-0.6b"))
-        .unwrap();
+    let second = config.resolve_embedding_model(Some(ALIAS)).unwrap();
     assert_eq!(first, second);
-    assert_eq!(first.dimensions, 1024);
+    assert_eq!(first.dimensions, 1_024);
     assert_eq!(first.auth_kind, "bearer");
+    assert_eq!(first.profile, PROFILE);
+    assert_eq!(first.metric, AiEmbeddingMetric::Cosine);
+    assert!(!first.send_dimensions);
     let tokenizer = config.resolve_tokenizer(None).unwrap();
     assert_eq!(tokenizer.tokenizer, AiTokenizer::Qwen3);
-    assert_eq!(tokenizer.max_input_tokens, 8192);
+    assert_eq!(tokenizer.profile, PROFILE);
+    assert_eq!(tokenizer.max_input_tokens, 8_192);
     assert_ne!(tokenizer.contract_sha256, first.contract_sha256);
     let json = serde_json::to_string(&first).unwrap();
     assert!(!json.contains("AI_FIXTURE_KEY"));
     assert!(!json.contains("127.0.0.1"));
+    assert!(!json.contains("open-compute"));
 }
 
 #[test]
-fn provider_and_catalog_drift_fail_closed() {
+fn backend_profile_and_catalog_drift_fail_closed() {
     let mut config = configured();
-    config.providers.get_mut("fixture").unwrap().base_url = "http://example.com/v1".to_owned();
+    config
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .endpoint = "http://example.com/v1/embeddings".to_owned();
     assert!(config.validate().is_err());
 
     let mut config = configured();
     config
-        .embedding_models
-        .get_mut("@cf/qwen/qwen3-embedding-0.6b")
+        .embedding_profiles
+        .get_mut(PROFILE)
         .unwrap()
-        .dimensions = 768;
+        .dimensions = 0;
+    assert!(config.validate().is_err());
+
+    let mut config = configured();
+    config.embedding_models.get_mut(ALIAS).unwrap().profile = "missing/profile".into();
     assert!(config.validate().is_err());
 
     let mut config = configured();
@@ -77,55 +133,104 @@ fn provider_and_catalog_drift_fail_closed() {
 
     let mut config = configured();
     config
-        .embedding_models
-        .get_mut("@cf/qwen/qwen3-embedding-0.6b")
+        .embedding_profiles
+        .get_mut(PROFILE)
         .unwrap()
-        .tokenizer_artifact
+        .tokenizer
+        .artifact
         .path = PathBuf::from("relative/tokenizer.json");
     assert!(config.validate().is_err());
+}
 
+#[test]
+fn endpoint_auth_and_header_contracts_are_closed() {
     let mut config = configured();
     config
-        .embedding_models
-        .get_mut("@cf/qwen/qwen3-embedding-0.6b")
+        .backends
+        .get_mut("fixture-embeddings")
         .unwrap()
-        .tokenizer_artifact
-        .sha256 = "ABC".repeat(21);
+        .endpoint = "https://api.example.com/v1/embeddings".to_owned();
+    config.backends.get_mut("fixture-embeddings").unwrap().auth = AiAuthConfig::None;
     assert!(config.validate().is_err());
-}
-
-#[test]
-fn anonymous_auth_is_only_for_loopback_http() {
-    let mut config = configured();
-    config.providers.get_mut("fixture").unwrap().base_url = "https://api.example.com/v1".to_owned();
-    config.providers.get_mut("fixture").unwrap().auth = AiAuthConfig::None;
-    assert!(config.validate().is_err());
-    config.providers.get_mut("fixture").unwrap().auth = AiAuthConfig::Bearer {
-        secret: SecretReference {
-            env: Some("AI_FIXTURE_KEY".to_owned()),
-            file: None,
-        },
-    };
+    config.backends.get_mut("fixture-embeddings").unwrap().auth =
+        AiAuthConfig::Bearer { secret: secret() };
     config.validate().unwrap();
+
+    for endpoint in [
+        "not-a-url",
+        "ftp://example.com/v1/embeddings",
+        "https://user@example.com/v1/embeddings",
+        "https://example.com/v1/embeddings?x=1",
+        "https://example.com/v1/embeddings#fragment",
+        "https://example.com/a/../v1/embeddings",
+        "https://example.com/",
+        "https://example.com/v1/embeddings/",
+        "http://[::2]/v1/embeddings",
+    ] {
+        let mut invalid = configured();
+        invalid
+            .backends
+            .get_mut("fixture-embeddings")
+            .unwrap()
+            .endpoint = endpoint.to_owned();
+        assert!(invalid.validate().is_err(), "{endpoint}");
+    }
+
+    let mut custom_auth = configured();
+    custom_auth
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .auth = AiAuthConfig::Header {
+        name: "X-API-Key".to_owned(),
+        secret: secret(),
+    };
+    custom_auth.validate().unwrap();
+    let contract = custom_auth.resolve_embedding_model(None).unwrap();
+    assert_eq!(contract.auth_kind, "header");
+    assert_eq!(contract.auth_header_name.as_deref(), Some("x-api-key"));
+
+    for name in [
+        "Authorization",
+        "Host",
+        "Content-Type",
+        "Proxy-Test",
+        "bad name",
+    ] {
+        let mut invalid = configured();
+        invalid
+            .backends
+            .get_mut("fixture-embeddings")
+            .unwrap()
+            .headers = BTreeMap::from([(name.to_owned(), "value".to_owned())]);
+        assert!(invalid.validate().is_err(), "{name}");
+    }
+
+    let mut duplicate = configured();
+    duplicate
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .headers = BTreeMap::from([
+        ("X-Title".to_owned(), "one".to_owned()),
+        ("x-title".to_owned(), "two".to_owned()),
+    ]);
+    assert!(duplicate.validate().is_err());
 }
 
 #[test]
-fn every_operator_limit_and_timeout_relationship_is_bounded() {
-    let invalid = [
+fn limits_names_profiles_and_generation_protocols_are_validated() {
+    let invalid_limits = [
         ("max_provider_in_flight", 0_u64),
         ("max_provider_in_flight", 257),
         ("max_embedding_inputs_per_batch", 0),
         ("max_embedding_inputs_per_batch", 513),
         ("max_embedding_request_bytes", 0),
-        ("max_embedding_request_bytes", 16 * 1024 * 1024 + 1),
         ("max_embedding_response_bytes", 0),
-        ("max_embedding_response_bytes", 256 * 1024 * 1024 + 1),
         ("provider_timeout_ms", 0),
-        ("provider_timeout_ms", 300_001),
         ("query_timeout_ms", 0),
-        ("query_timeout_ms", 300_001),
     ];
-    for (field, value) in invalid {
+    for (field, value) in invalid_limits {
         let mut config = configured();
         match field {
             "max_provider_in_flight" => config.max_provider_in_flight = value as u16,
@@ -140,10 +245,10 @@ fn every_operator_limit_and_timeout_relationship_is_bounded() {
         }
         assert_eq!(
             config.validate().unwrap_err().code(),
-            ErrorCode::LimitInvalid,
-            "{field}"
+            ErrorCode::LimitInvalid
         );
     }
+
     let mut config = configured();
     config.provider_timeout_ms = 99;
     config.query_timeout_ms = 100;
@@ -151,135 +256,103 @@ fn every_operator_limit_and_timeout_relationship_is_bounded() {
         config.validate().unwrap_err().code(),
         ErrorCode::LimitInvalid
     );
-}
 
-#[test]
-fn provider_urls_names_aliases_and_model_text_are_canonical() {
-    for url in [
-        "not-a-url",
-        "ftp://example.com/v1",
-        "https://user@example.com/v1",
-        "https://example.com/v1?x=1",
-        "https://example.com/v1#fragment",
-        "https://example.com/other",
-        "http://[::2]/v1",
-    ] {
+    for name in ["", "9backend", "bad backend", &"x".repeat(65)] {
         let mut config = configured();
-        config.providers.get_mut("fixture").unwrap().base_url = url.to_string();
-        assert!(config.validate().is_err(), "{url}");
-    }
-    let mut loopback = configured();
-    loopback.providers.get_mut("fixture").unwrap().auth = AiAuthConfig::None;
-    loopback.validate().unwrap();
-    assert_eq!(AiAuthConfig::None.kind_token(), "none");
-    assert_eq!(
-        configured().providers["fixture"].auth.kind_token(),
-        "bearer"
-    );
-
-    for name in ["", "9provider", "bad provider", &"x".repeat(65)] {
-        let mut config = configured();
-        let provider = config.providers.remove("fixture").unwrap();
-        config.providers.insert(name.to_string(), provider);
+        let backend = config.backends.remove("fixture-embeddings").unwrap();
+        config.backends.insert(name.to_owned(), backend);
         assert!(config.validate().is_err(), "{name}");
     }
-    for alias in [
-        "missing-slash",
-        " bad/model",
-        "bad /model",
-        &"x".repeat(257),
-    ] {
-        let mut config = configured();
-        let model = config
-            .embedding_models
-            .remove("@cf/qwen/qwen3-embedding-0.6b")
-            .unwrap();
-        config.default_embedding_model = None;
-        config.embedding_models.insert(alias.to_string(), model);
-        assert!(config.validate().is_err(), "{alias}");
-    }
-    for field in ["remote_model", "model_revision", "tokenizer_revision"] {
-        let mut config = configured();
-        let model = config
-            .embedding_models
-            .get_mut("@cf/qwen/qwen3-embedding-0.6b")
-            .unwrap();
-        match field {
-            "remote_model" => model.remote_model = " trailing ".to_string(),
-            "model_revision" => model.model_revision.clear(),
-            "tokenizer_revision" => model.tokenizer_revision = "bad\nrevision".to_string(),
-            _ => unreachable!(),
-        }
-        assert!(config.validate().is_err(), "{field}");
-    }
+
+    let mut config = configured();
+    add_chat(&mut config);
+    config.default_generation_model = Some("fixture/chat".to_owned());
+    config.validate().unwrap();
+    config
+        .generation_models
+        .get_mut("fixture/chat")
+        .unwrap()
+        .backend = "fixture-embeddings".to_owned();
+    assert!(config.validate().is_err());
 }
 
 #[test]
-fn catalog_resolution_and_generation_validation_reject_drift() {
-    let empty = AiConfig::default();
-    assert!(empty.resolve_embedding_model(None).is_err());
-    assert!(empty.resolve_tokenizer(None).is_err());
+fn profile_changes_are_frozen_and_old_provider_shape_is_rejected() {
     let config = configured();
-    assert!(
-        config
-            .resolve_embedding_model(Some("missing/model"))
-            .is_err()
+    let original = config.resolve_embedding_model(None).unwrap();
+    let mut changed = config.clone();
+    changed
+        .embedding_profiles
+        .get_mut(PROFILE)
+        .unwrap()
+        .send_dimensions = true;
+    let changed = changed.resolve_embedding_model(None).unwrap();
+    assert_ne!(
+        original.profile_contract_sha256,
+        changed.profile_contract_sha256
     );
-    assert!(config.resolve_tokenizer(Some("missing/model")).is_err());
+    assert_ne!(original.contract_sha256, changed.contract_sha256);
 
-    for mutate in 0..5 {
-        let mut config = configured();
-        let model = config
-            .embedding_models
-            .get_mut("@cf/qwen/qwen3-embedding-0.6b")
-            .unwrap();
-        match mutate {
-            0 => model.provider = "missing".to_string(),
-            1 => model.max_input_tokens = 512,
-            2 => model.request_dimensions = Some(768),
-            3 => model.tokenizer_artifact.path = PathBuf::from("/opt/../tokenizer.json"),
-            4 => model.tokenizer_artifact.sha256 = "g".repeat(64),
-            _ => unreachable!(),
-        }
-        assert!(config.validate().is_err(), "mutation {mutate}");
-    }
+    let mut header_case = config.clone();
+    header_case
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .headers = BTreeMap::from([
+        ("a-header".to_owned(), "first".to_owned()),
+        ("Z-Header".to_owned(), "last".to_owned()),
+    ]);
+    let first = header_case.resolve_embedding_model(None).unwrap();
+    header_case
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .headers = BTreeMap::from([
+        ("A-HEADER".to_owned(), "first".to_owned()),
+        ("z-header".to_owned(), "last".to_owned()),
+    ]);
+    let second = header_case.resolve_embedding_model(None).unwrap();
+    assert_eq!(first.headers_sha256, second.headers_sha256);
+    assert_eq!(first.contract_sha256, second.contract_sha256);
 
-    let generation = AiGenerationModelConfig {
-        provider: "fixture".to_string(),
-        remote_model: "fixture-chat".to_string(),
-        model_revision: "revision-1".to_string(),
-        max_context_tokens: 8_192,
-        capabilities: [
-            AiGenerationCapability::Chat,
-            AiGenerationCapability::Rewrite,
-        ]
-        .into_iter()
-        .collect(),
+    let mut rotated_secret = config.clone();
+    rotated_secret
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .auth = AiAuthConfig::Bearer {
+        secret: SecretReference {
+            env: Some("ROTATED_FIXTURE_KEY".to_owned()),
+            file: None,
+        },
     };
-    let mut valid = configured();
-    valid
-        .generation_models
-        .insert("fixture/chat".to_string(), generation.clone());
-    valid.default_generation_model = Some("fixture/chat".to_string());
-    valid.validate().unwrap();
+    assert_eq!(
+        original.contract_sha256,
+        rotated_secret
+            .resolve_embedding_model(None)
+            .unwrap()
+            .contract_sha256
+    );
 
-    for mutate in 0..5 {
-        let mut config = configured();
-        let mut model = generation.clone();
-        match mutate {
-            0 => model.provider = "missing".to_string(),
-            1 => model.max_context_tokens = 0,
-            2 => model.max_context_tokens = 4_000_001,
-            3 => model.capabilities.clear(),
-            4 => model.remote_model = "".to_string(),
-            _ => unreachable!(),
-        }
-        config
-            .generation_models
-            .insert("fixture/chat".to_string(), model);
-        assert!(config.validate().is_err(), "generation mutation {mutate}");
-    }
-    let mut config = configured();
-    config.default_generation_model = Some("missing/chat".to_string());
-    assert!(config.validate().is_err());
+    let mut routed_header = config.clone();
+    routed_header
+        .backends
+        .get_mut("fixture-embeddings")
+        .unwrap()
+        .headers
+        .insert("X-Title".to_owned(), "different-route".to_owned());
+    assert_ne!(
+        original.contract_sha256,
+        routed_header
+            .resolve_embedding_model(None)
+            .unwrap()
+            .contract_sha256
+    );
+
+    let old = r#"
+        [providers.fixture]
+        base_url = "http://127.0.0.1:8080/v1"
+        auth = { kind = "none" }
+    "#;
+    assert!(toml::from_str::<AiConfig>(old).is_err());
 }

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -174,8 +174,9 @@ master_key_file = "../../state/keys/master.key"
 backend = "local"
 path = "../../state/objects"
 
-[ai.providers.example]
-base_url = "http://127.0.0.1:8123/v1"
+[ai.backends.example]
+protocol = "openai_embeddings_v1"
+endpoint = "http://127.0.0.1:8123/v1/embeddings"
 auth = { kind = "bearer", secret = { file = "~/literal-$HOME-*.key" } }
 "#,
         base,
@@ -194,7 +195,7 @@ auth = { kind = "bearer", secret = { file = "~/literal-$HOME-*.key" } }
         local.object_storage.as_local().unwrap().path,
         Path::new("/srv/open-compute/state/objects")
     );
-    let AiAuthConfig::Bearer { secret } = &local.ai.providers["example"].auth else {
+    let AiAuthConfig::Bearer { secret } = &local.ai.backends["example"].auth else {
         panic!("expected bearer auth");
     };
     assert_eq!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,8 +38,9 @@ pub use capability::{
 };
 pub use clock::{Clock, SystemClock};
 pub use config::{
-    AiAuthConfig, AiConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiGenerationCapability,
-    AiGenerationModelConfig, AiProviderConfig, AiTokenizer, AiTokenizerArtifactConfig,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiConfig, AiEmbeddingMetric,
+    AiEmbeddingModelConfig, AiEmbeddingProfileConfig, AiGenerationCapability,
+    AiGenerationModelConfig, AiTokenizer, AiTokenizerArtifactConfig, AiTokenizerConfig,
     ArtifactsConfig, CacheConfig, D1Config, DataConfig, DocumentParserConfig, DurableObjectsConfig,
     HardeningConfig, ImagesConfig, KvConfig, LocalObjectStorageConfig, MetricsConfig,
     ObjectStorageConfig, ObjectStorageKind, PlatformConfig, QueuesConfig, R2Config,

--- a/crates/document-parser/src/lib.rs
+++ b/crates/document-parser/src/lib.rs
@@ -276,7 +276,7 @@ pub enum DocumentErrorCode {
     DocumentEncrypted,
     /// Document has no indexable content.
     DocumentEmpty,
-    /// PDF requires OCR, which is deliberately disabled for P5.7.
+    /// PDF requires OCR, which is deliberately disabled for P5.1.
     DocumentOcrRequired,
     /// Xberg could not parse the admitted document.
     DocumentParseFailed,

--- a/crates/service/src/ai_provider.rs
+++ b/crates/service/src/ai_provider.rs
@@ -3,14 +3,14 @@
 use crate::auth::resolve_admin_auth;
 use bytes::Bytes;
 use http_body_util::{BodyExt as _, Full, Limited};
-use hyper::header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue, RETRY_AFTER};
+use hyper::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, RETRY_AFTER};
 use hyper::{Method, Request, StatusCode, Uri};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::Client;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use open_compute_core::{
-    AiAuthConfig, AiConfig, AiGenerationCapability, ResolvedEmbeddingModelContract, SecretString,
+    AiAuthConfig, AiBackendConfig, AiConfig, AiGenerationCapability, ResolvedEmbeddingModelContract,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -130,7 +130,7 @@ pub struct OpenAiProviderClient {
     contract_sha256: String,
     dimensions: usize,
     request_dimensions: Option<u32>,
-    auth: Option<SecretString>,
+    headers: HeaderMap,
     max_inputs: usize,
     max_request_bytes: usize,
     max_response_bytes: usize,
@@ -160,19 +160,15 @@ impl OpenAiProviderClient {
         if &resolved != contract {
             return Err(AiProviderError::ContractMismatch);
         }
-        let provider = config
-            .providers
-            .get(&contract.provider_name)
+        let backend = config
+            .backends
+            .get(&contract.backend_name)
             .ok_or(AiProviderError::ContractMismatch)?;
-        let endpoint = format!("{}/embeddings", provider.base_url.trim_end_matches('/'))
+        let endpoint = backend
+            .endpoint
             .parse::<Uri>()
             .map_err(|_| AiProviderError::ContractMismatch)?;
-        let auth = match &provider.auth {
-            AiAuthConfig::None => None,
-            AiAuthConfig::Bearer { secret } => {
-                Some(resolve_admin_auth(secret).map_err(|_| AiProviderError::ContractMismatch)?)
-            }
-        };
+        let headers = resolve_backend_headers(backend)?;
         let connector = HttpsConnectorBuilder::new()
             .with_webpki_roots()
             .https_or_http()
@@ -185,8 +181,8 @@ impl OpenAiProviderClient {
             contract_sha256: contract.contract_sha256.clone(),
             dimensions: usize::try_from(contract.dimensions)
                 .map_err(|_| AiProviderError::ContractMismatch)?,
-            request_dimensions: contract.request_dimensions,
-            auth,
+            request_dimensions: contract.send_dimensions.then_some(contract.dimensions),
+            headers,
             max_inputs: usize::from(config.max_embedding_inputs_per_batch),
             max_request_bytes: usize::try_from(config.max_embedding_request_bytes)
                 .map_err(|_| AiProviderError::ContractMismatch)?,
@@ -232,19 +228,14 @@ impl OpenAiProviderClient {
         if body.len() > self.max_request_bytes {
             return Err(AiProviderError::InvalidRequest);
         }
-        let mut builder = Request::builder()
+        let builder = Request::builder()
             .method(Method::POST)
             .uri(&self.endpoint)
             .header(CONTENT_TYPE, "application/json");
-        if let Some(secret) = &self.auth {
-            let mut value = HeaderValue::from_str(&format!("Bearer {}", secret.expose()))
-                .map_err(|_| AiProviderError::ContractMismatch)?;
-            value.set_sensitive(true);
-            builder = builder.header(AUTHORIZATION, value);
-        }
-        let request = builder
+        let mut request = builder
             .body(Full::new(Bytes::from(body)))
             .map_err(|_| AiProviderError::InvalidRequest)?;
+        apply_backend_headers(&mut request, &self.headers);
         let response = tokio::time::timeout(self.timeout, self.transport.request(request))
             .await
             .map_err(|_| AiProviderError::Timeout)?
@@ -296,21 +287,25 @@ impl OpenAiProviderClient {
         input_count: usize,
     ) -> Result<EmbeddingBatch, AiProviderError> {
         if response.object != "list"
-            || response.model != self.remote_model
+            || !valid_response_model(response.model.as_deref())
             || response.data.len() != input_count
         {
             return Err(AiProviderError::MalformedResponse);
         }
-        let mut embeddings = Vec::with_capacity(input_count);
-        for (expected_index, item) in response.data.into_iter().enumerate() {
+        let mut embeddings = vec![None; input_count];
+        for item in response.data {
             if item.object != "embedding"
-                || item.index != expected_index
                 || item.embedding.len() != self.dimensions
                 || item.embedding.iter().any(|value| !value.is_finite())
             {
                 return Err(AiProviderError::MalformedResponse);
             }
-            embeddings.push(item.embedding);
+            let slot = embeddings
+                .get_mut(item.index)
+                .ok_or(AiProviderError::MalformedResponse)?;
+            if slot.replace(item.embedding).is_some() {
+                return Err(AiProviderError::MalformedResponse);
+            }
         }
         if response
             .usage
@@ -319,6 +314,10 @@ impl OpenAiProviderClient {
         {
             return Err(AiProviderError::MalformedResponse);
         }
+        let embeddings = embeddings
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(AiProviderError::MalformedResponse)?;
         Ok(EmbeddingBatch {
             embeddings,
             prompt_tokens: response.usage.map(|usage| usage.prompt_tokens),
@@ -332,8 +331,8 @@ pub struct OpenAiChatClient {
     transport: ProviderTransport,
     endpoint: Uri,
     remote_model: String,
-    model_revision: String,
-    auth: Option<SecretString>,
+    provider_revision: Option<String>,
+    headers: HeaderMap,
     max_request_bytes: usize,
     max_response_bytes: usize,
     timeout: Duration,
@@ -344,7 +343,7 @@ impl std::fmt::Debug for OpenAiChatClient {
         formatter
             .debug_struct("OpenAiChatClient")
             .field("remote_model", &self.remote_model)
-            .field("model_revision", &self.model_revision)
+            .field("provider_revision", &self.provider_revision)
             .finish_non_exhaustive()
     }
 }
@@ -364,22 +363,15 @@ impl OpenAiChatClient {
             .get(alias)
             .filter(|model| model.capabilities.contains(&capability))
             .ok_or(AiProviderError::ContractMismatch)?;
-        let provider = config
-            .providers
-            .get(&model.provider)
+        let backend = config
+            .backends
+            .get(&model.backend)
             .ok_or(AiProviderError::ContractMismatch)?;
-        let endpoint = format!(
-            "{}/chat/completions",
-            provider.base_url.trim_end_matches('/')
-        )
-        .parse::<Uri>()
-        .map_err(|_| AiProviderError::ContractMismatch)?;
-        let auth = match &provider.auth {
-            AiAuthConfig::None => None,
-            AiAuthConfig::Bearer { secret } => {
-                Some(resolve_admin_auth(secret).map_err(|_| AiProviderError::ContractMismatch)?)
-            }
-        };
+        let endpoint = backend
+            .endpoint
+            .parse::<Uri>()
+            .map_err(|_| AiProviderError::ContractMismatch)?;
+        let headers = resolve_backend_headers(backend)?;
         let connector = HttpsConnectorBuilder::new()
             .with_webpki_roots()
             .https_or_http()
@@ -389,8 +381,8 @@ impl OpenAiChatClient {
             transport: Client::builder(TokioExecutor::new()).build(connector),
             endpoint,
             remote_model: model.remote_model.clone(),
-            model_revision: model.model_revision.clone(),
-            auth,
+            provider_revision: model.provider_revision.clone(),
+            headers,
             max_request_bytes: usize::try_from(config.max_embedding_request_bytes)
                 .map_err(|_| AiProviderError::ContractMismatch)?,
             max_response_bytes: usize::try_from(config.max_embedding_response_bytes)
@@ -419,7 +411,7 @@ impl OpenAiChatClient {
         .to_bytes();
         let response: ChatResponse =
             serde_json::from_slice(&bytes).map_err(|_| AiProviderError::MalformedResponse)?;
-        if response.model != self.remote_model || response.choices.len() != 1 {
+        if !valid_response_model(response.model.as_deref()) || response.choices.len() != 1 {
             return Err(AiProviderError::MalformedResponse);
         }
         let choice = response
@@ -541,19 +533,14 @@ impl OpenAiChatClient {
         if body.len() > self.max_request_bytes {
             return Err(AiProviderError::InvalidRequest);
         }
-        let mut builder = Request::builder()
+        let builder = Request::builder()
             .method(Method::POST)
             .uri(&self.endpoint)
             .header(CONTENT_TYPE, "application/json");
-        if let Some(secret) = &self.auth {
-            let mut value = HeaderValue::from_str(&format!("Bearer {}", secret.expose()))
-                .map_err(|_| AiProviderError::ContractMismatch)?;
-            value.set_sensitive(true);
-            builder = builder.header(AUTHORIZATION, value);
-        }
-        let request = builder
+        let mut request = builder
             .body(Full::new(Bytes::from(body)))
             .map_err(|_| AiProviderError::InvalidRequest)?;
+        apply_backend_headers(&mut request, &self.headers);
         let response = tokio::time::timeout(self.timeout, self.transport.request(request))
             .await
             .map_err(|_| AiProviderError::Timeout)?
@@ -662,6 +649,53 @@ fn content_type_is(response: &hyper::Response<hyper::body::Incoming>, expected: 
         .is_some_and(|value| value.split(';').next() == Some(expected))
 }
 
+fn resolve_backend_headers(backend: &AiBackendConfig) -> Result<HeaderMap, AiProviderError> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in &backend.headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|_| AiProviderError::ContractMismatch)?;
+        let value = HeaderValue::from_str(value).map_err(|_| AiProviderError::ContractMismatch)?;
+        headers.insert(name, value);
+    }
+    match &backend.auth {
+        AiAuthConfig::None => {}
+        AiAuthConfig::Bearer { secret } => {
+            let secret =
+                resolve_admin_auth(secret).map_err(|_| AiProviderError::ContractMismatch)?;
+            let mut value = HeaderValue::from_str(&format!("Bearer {}", secret.expose()))
+                .map_err(|_| AiProviderError::ContractMismatch)?;
+            value.set_sensitive(true);
+            headers.insert(AUTHORIZATION, value);
+        }
+        AiAuthConfig::Header { name, secret } => {
+            let name = HeaderName::from_bytes(name.as_bytes())
+                .map_err(|_| AiProviderError::ContractMismatch)?;
+            let secret =
+                resolve_admin_auth(secret).map_err(|_| AiProviderError::ContractMismatch)?;
+            let mut value = HeaderValue::from_str(secret.expose())
+                .map_err(|_| AiProviderError::ContractMismatch)?;
+            value.set_sensitive(true);
+            headers.insert(name, value);
+        }
+    }
+    Ok(headers)
+}
+
+fn apply_backend_headers(request: &mut Request<Full<Bytes>>, headers: &HeaderMap) {
+    for (name, value) in headers {
+        request.headers_mut().insert(name, value.clone());
+    }
+}
+
+fn valid_response_model(model: Option<&str>) -> bool {
+    model.is_none_or(|value| {
+        !value.is_empty()
+            && value.len() <= 256
+            && value.trim() == value
+            && !value.chars().any(char::is_control)
+    })
+}
+
 #[derive(Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,
@@ -672,7 +706,8 @@ struct ChatRequest<'a> {
 
 #[derive(Deserialize)]
 struct ChatResponse {
-    model: String,
+    #[serde(default)]
+    model: Option<String>,
     choices: Vec<ChatChoice>,
 }
 
@@ -715,17 +750,16 @@ struct EmbeddingRequest<'a> {
 }
 
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
 struct EmbeddingResponse {
     object: String,
-    model: String,
+    #[serde(default)]
+    model: Option<String>,
     data: Vec<EmbeddingData>,
     #[serde(default)]
     usage: Option<EmbeddingUsage>,
 }
 
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
 struct EmbeddingData {
     object: String,
     index: usize,
@@ -733,7 +767,6 @@ struct EmbeddingData {
 }
 
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
 struct EmbeddingUsage {
     prompt_tokens: u64,
     total_tokens: u64,

--- a/crates/service/src/ai_provider_tests.rs
+++ b/crates/service/src/ai_provider_tests.rs
@@ -8,9 +8,9 @@ use hyper::service::service_fn;
 use hyper::{Request as HyperRequest, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use open_compute_core::{
-    AiAuthConfig, AiConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiGenerationCapability,
-    AiGenerationModelConfig, AiProviderConfig, AiTokenizer, AiTokenizerArtifactConfig,
-    SecretReference,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiConfig, AiEmbeddingModelConfig,
+    AiEmbeddingProfileConfig, AiGenerationCapability, AiGenerationModelConfig, AiTokenizer,
+    AiTokenizerArtifactConfig, AiTokenizerConfig, SecretReference,
 };
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
@@ -19,6 +19,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 
 type ScriptedResponse = (StatusCode, &'static str, Vec<u8>);
 
@@ -72,6 +73,51 @@ impl ScriptedServer {
     }
 }
 
+struct CapturedRequest {
+    path: String,
+    headers: HeaderMap,
+    body: Vec<u8>,
+}
+
+async fn capture_one(body: Vec<u8>) -> (u16, oneshot::Receiver<CapturedRequest>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (sender, receiver) = oneshot::channel();
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let io = TokioIo::new(stream);
+        let _ = http1::Builder::new()
+            .serve_connection(
+                io,
+                service_fn(move |request: HyperRequest<HyperIncoming>| {
+                    let sender = sender.clone();
+                    let body = body.clone();
+                    async move {
+                        let (parts, incoming) = request.into_parts();
+                        let request_body = incoming.collect().await.unwrap().to_bytes().to_vec();
+                        if let Some(sender) = sender.lock().unwrap().take() {
+                            let _ = sender.send(CapturedRequest {
+                                path: parts.uri.path().to_owned(),
+                                headers: parts.headers,
+                                body: request_body,
+                            });
+                        }
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(StatusCode::OK)
+                                .header(CONTENT_TYPE, "application/json")
+                                .body(Full::new(Bytes::from(body)))
+                                .unwrap(),
+                        )
+                    }
+                }),
+            )
+            .await;
+    });
+    (port, receiver)
+}
+
 fn tokenizer_fixture() -> (PathBuf, String) {
     let path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tokenizer-word-level.json");
@@ -79,7 +125,7 @@ fn tokenizer_fixture() -> (PathBuf, String) {
     (path, hex::encode(Sha256::digest(bytes)))
 }
 
-fn embedding_config(base_url: &str) -> AiConfig {
+fn embedding_config(root: &str) -> AiConfig {
     let (path, sha256) = tokenizer_fixture();
     let mut config = AiConfig {
         provider_timeout_ms: 2_000,
@@ -87,35 +133,54 @@ fn embedding_config(base_url: &str) -> AiConfig {
         max_embedding_inputs_per_batch: 8,
         ..AiConfig::default()
     };
-    config.providers.insert(
-        "fixture".to_owned(),
-        AiProviderConfig {
-            base_url: base_url.to_owned(),
+    config.backends.insert(
+        "fixture-embeddings".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: format!("{root}/embeddings"),
             auth: AiAuthConfig::None,
+            headers: Default::default(),
         },
     );
     let alias = "@cf/qwen/qwen3-embedding-0.6b";
+    let profile = "fixture/qwen3-1024";
+    config.embedding_profiles.insert(
+        profile.to_owned(),
+        AiEmbeddingProfileConfig {
+            dimensions: 1_024,
+            max_input_tokens: 8_192,
+            send_dimensions: false,
+            tokenizer: AiTokenizerConfig {
+                kind: AiTokenizer::Qwen3,
+                revision: "fixture-tokenizer".to_owned(),
+                artifact: AiTokenizerArtifactConfig { path, sha256 },
+            },
+        },
+    );
     config.embedding_models.insert(
         alias.to_owned(),
         AiEmbeddingModelConfig {
-            provider: "fixture".to_owned(),
+            backend: "fixture-embeddings".to_owned(),
             remote_model: alias.to_owned(),
-            model_revision: "fixture-model".to_owned(),
-            dimensions: 1_024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8_192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "fixture-tokenizer".to_owned(),
-            tokenizer_artifact: AiTokenizerArtifactConfig { path, sha256 },
+            provider_revision: Some("fixture-model".to_owned()),
+            profile: profile.to_owned(),
         },
     );
     config.default_embedding_model = Some(alias.to_owned());
     config
 }
 
-fn chat_config(base_url: &str) -> AiConfig {
-    let mut config = embedding_config(base_url);
+fn chat_config(root: &str) -> AiConfig {
+    let mut config = embedding_config(root);
+    config.backends.insert(
+        "fixture-chat".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiChatCompletionsV1,
+            endpoint: format!("{root}/chat/completions"),
+            auth: AiAuthConfig::None,
+            headers: Default::default(),
+        },
+    );
     let mut capabilities = BTreeSet::new();
     capabilities.insert(AiGenerationCapability::Chat);
     capabilities.insert(AiGenerationCapability::Rewrite);
@@ -123,9 +188,9 @@ fn chat_config(base_url: &str) -> AiConfig {
     config.generation_models.insert(
         "fixture/chat".to_owned(),
         AiGenerationModelConfig {
-            provider: "fixture".to_owned(),
+            backend: "fixture-chat".to_owned(),
             remote_model: "fixture-chat".to_owned(),
-            model_revision: "rev-1".to_owned(),
+            provider_revision: Some("rev-1".to_owned()),
             max_context_tokens: 4_096,
             capabilities,
         },
@@ -220,6 +285,71 @@ async fn embeddings_success_and_request_validation() {
             .unwrap_err(),
         AiProviderError::InvalidRequest
     );
+}
+
+#[tokio::test]
+async fn exact_prefixed_endpoint_headers_and_compatible_response_are_supported() {
+    let response = serde_json::to_vec(&serde_json::json!({
+        "object": "list",
+        "model": "provider-canonicalized-model",
+        "provider_extension": true,
+        "data": [
+            {
+                "object": "embedding",
+                "index": 1,
+                "embedding": vec![0.25_f32; 1_024],
+                "extension": "ignored"
+            },
+            {
+                "object": "embedding",
+                "index": 0,
+                "embedding": vec![0.5_f32; 1_024]
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "total_tokens": 4, "extension": 1}
+    }))
+    .unwrap();
+    let (port, captured) = capture_one(response).await;
+    let root = tempfile::tempdir().unwrap();
+    let secret_path = root.path().join("api-key");
+    fs::write(&secret_path, b"secret-value\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(&secret_path, fs::Permissions::from_mode(0o600)).unwrap();
+
+    let mut config = embedding_config(&format!(
+        "http://127.0.0.1:{port}/tenant/acme/compatible-mode/v1"
+    ));
+    let backend = config.backends.get_mut("fixture-embeddings").unwrap();
+    backend.auth = AiAuthConfig::Header {
+        name: "X-API-Key".to_owned(),
+        secret: SecretReference {
+            env: None,
+            file: Some(secret_path),
+        },
+    };
+    backend
+        .headers
+        .insert("X-Title".to_owned(), "open-compute".to_owned());
+    config
+        .embedding_profiles
+        .get_mut("fixture/qwen3-1024")
+        .unwrap()
+        .send_dimensions = true;
+    let contract = config.resolve_embedding_model(None).unwrap();
+    let client = OpenAiProviderClient::new(&config, &contract).unwrap();
+    let batch = client
+        .embeddings(&["first".to_owned(), "second".to_owned()])
+        .await
+        .unwrap();
+    assert_eq!(batch.embeddings[0][0], 0.5);
+    assert_eq!(batch.embeddings[1][0], 0.25);
+
+    let captured = captured.await.unwrap();
+    assert_eq!(captured.path, "/tenant/acme/compatible-mode/v1/embeddings");
+    assert_eq!(captured.headers["x-api-key"], "secret-value");
+    assert_eq!(captured.headers["x-title"], "open-compute");
+    let request: serde_json::Value = serde_json::from_slice(&captured.body).unwrap();
+    assert_eq!(request["dimensions"], 1_024);
 }
 
 #[tokio::test]
@@ -456,37 +586,13 @@ fn client_constructors_fail_closed_on_contract_drift() {
 
 #[test]
 fn bearer_auth_resolves_from_env_secret() {
-    let (path, sha256) = tokenizer_fixture();
-    let mut config = AiConfig::default();
-    config.providers.insert(
-        "fixture".to_owned(),
-        AiProviderConfig {
-            base_url: "http://127.0.0.1:9/v1".to_owned(),
-            auth: AiAuthConfig::Bearer {
-                secret: SecretReference {
-                    env: Some("OPEN_COMPUTE_AI_PROVIDER_TEST_TOKEN".to_owned()),
-                    file: None,
-                },
-            },
+    let mut config = embedding_config("http://127.0.0.1:9/v1");
+    config.backends.get_mut("fixture-embeddings").unwrap().auth = AiAuthConfig::Bearer {
+        secret: SecretReference {
+            env: Some("OPEN_COMPUTE_AI_PROVIDER_TEST_TOKEN".to_owned()),
+            file: None,
         },
-    );
-    let alias = "@cf/qwen/qwen3-embedding-0.6b";
-    config.embedding_models.insert(
-        alias.to_owned(),
-        AiEmbeddingModelConfig {
-            provider: "fixture".to_owned(),
-            remote_model: alias.to_owned(),
-            model_revision: "fixture-model".to_owned(),
-            dimensions: 1_024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8_192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "fixture-tokenizer".to_owned(),
-            tokenizer_artifact: AiTokenizerArtifactConfig { path, sha256 },
-        },
-    );
-    config.default_embedding_model = Some(alias.to_owned());
+    };
     // Missing env fails closed.
     let contract = config.resolve_embedding_model(None).unwrap();
     assert_eq!(
@@ -546,7 +652,7 @@ async fn chat_stream_rejects_malformed_choice_shapes_and_sends_bearer() {
     fs::write(&token_path, b"test-token\n").unwrap();
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(&token_path, fs::Permissions::from_mode(0o600)).unwrap();
-    config.providers.get_mut("fixture").unwrap().auth = AiAuthConfig::Bearer {
+    config.backends.get_mut("fixture-chat").unwrap().auth = AiAuthConfig::Bearer {
         secret: SecretReference {
             env: None,
             file: Some(token_path.clone()),

--- a/crates/service/src/ai_search_backend/tests/mod.rs
+++ b/crates/service/src/ai_search_backend/tests/mod.rs
@@ -17,8 +17,9 @@ use open_compute_artifacts::{
 };
 use open_compute_core::config::MetricsConfig;
 use open_compute_core::{
-    AiAuthConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiProviderConfig, AiTokenizer,
-    AiTokenizerArtifactConfig, DocumentParserConfig, PlatformConfig, SecretString,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiEmbeddingModelConfig,
+    AiEmbeddingProfileConfig, AiTokenizer, AiTokenizerArtifactConfig, AiTokenizerConfig,
+    DocumentParserConfig, PlatformConfig, SecretString,
 };
 use open_compute_storage::AiSearchObjectReference;
 use open_compute_storage::{ResourceRecord, StagedAiSearchChunk};
@@ -233,30 +234,40 @@ fn keyword_ai_config() -> AiConfig {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tokenizer-word-level.json");
     let bytes = std::fs::read(&path).unwrap();
     let mut config = AiConfig::default();
-    config.providers.insert(
+    config.backends.insert(
         "fixture".to_owned(),
-        AiProviderConfig {
-            base_url: "http://127.0.0.1:8080/v1".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: "http://127.0.0.1:8080/v1/embeddings".to_owned(),
             auth: AiAuthConfig::None,
+            headers: Default::default(),
         },
     );
     let alias = "@cf/qwen/qwen3-embedding-0.6b";
+    let profile = "fixture/qwen3";
+    config.embedding_profiles.insert(
+        profile.to_owned(),
+        AiEmbeddingProfileConfig {
+            dimensions: 1_024,
+            max_input_tokens: 8_192,
+            send_dimensions: false,
+            tokenizer: AiTokenizerConfig {
+                kind: AiTokenizer::Qwen3,
+                revision: "fixture-tokenizer".to_owned(),
+                artifact: AiTokenizerArtifactConfig {
+                    path,
+                    sha256: hex::encode(Sha256::digest(bytes)),
+                },
+            },
+        },
+    );
     config.embedding_models.insert(
         alias.to_owned(),
         AiEmbeddingModelConfig {
-            provider: "fixture".to_owned(),
+            backend: "fixture".to_owned(),
             remote_model: alias.to_owned(),
-            model_revision: "fixture-model".to_owned(),
-            dimensions: 1_024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8_192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "fixture-tokenizer".to_owned(),
-            tokenizer_artifact: AiTokenizerArtifactConfig {
-                path,
-                sha256: hex::encode(Sha256::digest(bytes)),
-            },
+            provider_revision: Some("fixture-model".to_owned()),
+            profile: profile.to_owned(),
         },
     );
     config.default_embedding_model = Some(alias.to_owned());

--- a/crates/service/src/ai_search_config_tests.rs
+++ b/crates/service/src/ai_search_config_tests.rs
@@ -16,20 +16,21 @@ prefix = "system/"
 [ai]
 default_embedding_model = "@cf/qwen/qwen3-embedding-0.6b"
 
-[ai.providers.fixture]
-base_url = "http://127.0.0.1:8080/v1"
+[ai.backends.fixture]
+protocol = "openai_embeddings_v1"
+endpoint = "http://127.0.0.1:8080/v1/embeddings"
 auth = { kind = "none" }
 
-[ai.embedding_models."@cf/qwen/qwen3-embedding-0.6b"]
-provider = "fixture"
-remote_model = "@cf/qwen/qwen3-embedding-0.6b"
-model_revision = "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3"
+[ai.embedding_profiles."fixture/qwen3"]
 dimensions = 1024
-metric = "cosine"
 max_input_tokens = 8192
-tokenizer = "qwen3"
-tokenizer_revision = "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3"
-tokenizer_artifact = { path = "/opt/open-compute/models/qwen3/tokenizer.json", sha256 = "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a" }
+tokenizer = { kind = "qwen3", revision = "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3", artifact = { path = "/opt/open-compute/models/qwen3/tokenizer.json", sha256 = "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a" } }
+
+[ai.embedding_models."@cf/qwen/qwen3-embedding-0.6b"]
+backend = "fixture"
+remote_model = "@cf/qwen/qwen3-embedding-0.6b"
+provider_revision = "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3"
+profile = "fixture/qwen3"
 "#,
     )
     .unwrap()

--- a/crates/service/src/ai_search_coordinator_tests.rs
+++ b/crates/service/src/ai_search_coordinator_tests.rs
@@ -1,17 +1,70 @@
 //! Focused coordinator recovery tests.
 
 use super::*;
+use open_compute_core::{
+    AiEmbeddingMetric, AiTokenizer, ResolvedEmbeddingModelContract, ResolvedTokenizerContract,
+};
 use open_compute_storage::{AiSearchInstanceStorageContract, NewAiSearchItemGeneration};
 use uuid::Uuid;
+
+fn contract_digest<T: serde::Serialize>(contract: &T) -> String {
+    hex::encode(Sha256::digest(
+        serde_json::to_vec(contract).expect("serialize unsigned contract"),
+    ))
+}
+
+fn model_contract(vector_enabled: bool) -> Vec<u8> {
+    let digest = "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a";
+    if vector_enabled {
+        let mut contract = ResolvedEmbeddingModelContract {
+            embedding_alias: "fixture/embed".to_owned(),
+            backend_name: "fixture".to_owned(),
+            backend_contract_sha256: digest.to_owned(),
+            protocol: "openai_embeddings_v1".to_owned(),
+            endpoint_sha256: digest.to_owned(),
+            auth_kind: "none".to_owned(),
+            auth_header_name: None,
+            headers_sha256: digest.to_owned(),
+            remote_model: "fixture".to_owned(),
+            provider_revision: None,
+            profile: "fixture/profile".to_owned(),
+            profile_contract_sha256: digest.to_owned(),
+            dimensions: 1,
+            send_dimensions: false,
+            metric: AiEmbeddingMetric::Cosine,
+            max_input_tokens: 512,
+            tokenizer: AiTokenizer::Custom,
+            tokenizer_revision: "1".to_owned(),
+            tokenizer_artifact_sha256: digest.to_owned(),
+            contract_sha256: String::new(),
+        };
+        contract.contract_sha256 = contract_digest(&contract);
+        serde_json::to_vec(&contract).expect("serialize model contract")
+    } else {
+        let mut contract = ResolvedTokenizerContract {
+            embedding_alias: "fixture/embed".to_owned(),
+            profile: "fixture/profile".to_owned(),
+            profile_contract_sha256: digest.to_owned(),
+            tokenizer: AiTokenizer::Custom,
+            tokenizer_revision: "1".to_owned(),
+            tokenizer_artifact_sha256: digest.to_owned(),
+            max_input_tokens: 512,
+            contract_sha256: String::new(),
+        };
+        contract.contract_sha256 = contract_digest(&contract);
+        serde_json::to_vec(&serde_json::json!({
+            "kind": "keyword_only",
+            "schemaVersion": 1,
+            "tokenizerContract": contract,
+        }))
+        .expect("serialize tokenizer contract")
+    }
+}
 
 fn open_store(vector_enabled: bool) -> (tempfile::TempDir, AiSearchStore) {
     let directory = tempfile::tempdir().expect("tempdir");
     let path = directory.path().join("instance.sqlite");
-    let model = if vector_enabled {
-        br#"{"dimensions":1,"metric":"cosine","tokenizer":"fixture","tokenizerRevision":"1","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#.as_slice()
-    } else {
-        br#"{"kind":"keyword_only","schemaVersion":1,"tokenizerContract":{"embeddingAlias":"fixture","tokenizer":"fixture","tokenizerRevision":"1","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a","maxInputTokens":512,"contractSha256":"fixture-contract"}}"#.as_slice()
-    };
+    let model = model_contract(vector_enabled);
     let public_config = if vector_enabled {
         br#"{"chunk":true,"chunk_overlap":2,"chunk_size":8,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#.as_slice()
     } else {
@@ -21,8 +74,8 @@ fn open_store(vector_enabled: bool) -> (tempfile::TempDir, AiSearchStore) {
         &path,
         &AiSearchInstanceStorageContract {
             resource_id: "instance-1",
-            model_contract_sha256: Sha256::digest(model).into(),
-            model_contract_json: model,
+            model_contract_sha256: Sha256::digest(&model).into(),
+            model_contract_json: &model,
             public_config_json: public_config,
             dimensions: u32::from(vector_enabled),
             vector_enabled,

--- a/crates/service/src/ai_tokenizer.rs
+++ b/crates/service/src/ai_tokenizer.rs
@@ -41,13 +41,17 @@ impl AiTokenizerRegistry {
         for (alias, model) in &config.embedding_models {
             let embedding_contract = config.resolve_embedding_model(Some(alias))?;
             let tokenizer_contract = config.resolve_tokenizer(Some(alias))?;
-            let tokenizer = if let Some(tokenizer) = artifacts.get(&model.tokenizer_artifact.sha256)
-            {
+            let profile = config
+                .embedding_profiles
+                .get(&model.profile)
+                .ok_or_else(invalid)?;
+            let artifact = &profile.tokenizer.artifact;
+            let tokenizer = if let Some(tokenizer) = artifacts.get(&artifact.sha256) {
                 tokenizer.clone()
             } else {
-                let bytes = read_artifact(&model.tokenizer_artifact.path)?;
+                let bytes = read_artifact(&artifact.path)?;
                 let digest = hex::encode(Sha256::digest(&bytes));
-                if digest != model.tokenizer_artifact.sha256 {
+                if digest != artifact.sha256 {
                     return Err(integrity());
                 }
                 let tokenizer = Tokenizer::from_bytes(&bytes).map_err(|_| invalid())?;
@@ -61,7 +65,7 @@ impl AiTokenizerRegistry {
                     return Err(invalid());
                 }
                 let tokenizer = Arc::new(tokenizer);
-                artifacts.insert(model.tokenizer_artifact.sha256.clone(), tokenizer.clone());
+                artifacts.insert(artifact.sha256.clone(), tokenizer.clone());
                 tokenizer
             };
             let frozen = Arc::new(FrozenAiTokenizer {
@@ -201,34 +205,44 @@ fn contract_mismatch() -> PlatformError {
 mod tests {
     use super::*;
     use open_compute_core::{
-        AiAuthConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiProviderConfig, AiTokenizer,
-        AiTokenizerArtifactConfig,
+        AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiEmbeddingModelConfig,
+        AiEmbeddingProfileConfig, AiTokenizer, AiTokenizerArtifactConfig, AiTokenizerConfig,
     };
     use std::path::PathBuf;
 
     fn fixture_config(path: PathBuf, sha256: String) -> AiConfig {
         let mut config = AiConfig::default();
-        config.providers.insert(
+        config.backends.insert(
             "fixture".to_owned(),
-            AiProviderConfig {
-                base_url: "http://127.0.0.1:8080/v1".to_owned(),
+            AiBackendConfig {
+                protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+                endpoint: "http://127.0.0.1:8080/v1/embeddings".to_owned(),
                 auth: AiAuthConfig::None,
+                headers: BTreeMap::new(),
             },
         );
         let alias = "@cf/qwen/qwen3-embedding-0.6b";
+        let profile = "fixture/qwen3";
+        config.embedding_profiles.insert(
+            profile.to_owned(),
+            AiEmbeddingProfileConfig {
+                dimensions: 1024,
+                max_input_tokens: 8192,
+                send_dimensions: false,
+                tokenizer: AiTokenizerConfig {
+                    kind: AiTokenizer::Qwen3,
+                    revision: "fixture-tokenizer".to_owned(),
+                    artifact: AiTokenizerArtifactConfig { path, sha256 },
+                },
+            },
+        );
         config.embedding_models.insert(
             alias.to_owned(),
             AiEmbeddingModelConfig {
-                provider: "fixture".to_owned(),
+                backend: "fixture".to_owned(),
                 remote_model: alias.to_owned(),
-                model_revision: "fixture-model".to_owned(),
-                dimensions: 1024,
-                request_dimensions: None,
-                metric: AiEmbeddingMetric::Cosine,
-                max_input_tokens: 8192,
-                tokenizer: AiTokenizer::Qwen3,
-                tokenizer_revision: "fixture-tokenizer".to_owned(),
-                tokenizer_artifact: AiTokenizerArtifactConfig { path, sha256 },
+                provider_revision: Some("fixture-model".to_owned()),
+                profile: profile.to_owned(),
             },
         );
         config.default_embedding_model = Some(alias.to_owned());

--- a/crates/service/src/doctor.rs
+++ b/crates/service/src/doctor.rs
@@ -121,9 +121,12 @@ pub use report::doctor_report;
 
 fn inspect_ai_provider_config(config: &AiConfig) -> Result<String, PlatformError> {
     config.validate()?;
-    for provider in config.providers.values() {
-        if let AiAuthConfig::Bearer { secret } = &provider.auth {
-            let _ = resolve_admin_auth(secret)?;
+    for backend in config.backends.values() {
+        match &backend.auth {
+            AiAuthConfig::Bearer { secret } | AiAuthConfig::Header { secret, .. } => {
+                let _ = resolve_admin_auth(secret)?;
+            }
+            AiAuthConfig::None => {}
         }
     }
     let _ = AiTokenizerRegistry::load(config)?;
@@ -132,8 +135,9 @@ fn inspect_ai_provider_config(config: &AiConfig) -> Result<String, PlatformError
         let _ = config.resolve_tokenizer(Some(alias))?;
     }
     Ok(format!(
-        "providers={} embedding_models={} generation_models={}",
-        config.providers.len(),
+        "backends={} embedding_profiles={} embedding_models={} generation_models={}",
+        config.backends.len(),
+        config.embedding_profiles.len(),
         config.embedding_models.len(),
         config.generation_models.len(),
     ))

--- a/crates/service/src/doctor_tests.rs
+++ b/crates/service/src/doctor_tests.rs
@@ -68,20 +68,22 @@ fn workflow_doctor_fails_closed_when_authority_is_unavailable() {
 fn ai_provider_readiness_is_local_and_requires_resolvable_credentials() {
     assert_eq!(
         inspect_ai_provider_config(&AiConfig::default()).unwrap(),
-        "providers=0 embedding_models=0 generation_models=0"
+        "backends=0 embedding_profiles=0 embedding_models=0 generation_models=0"
     );
     let mut config = AiConfig::default();
     let missing_secret = tempfile::tempdir().unwrap().path().join("missing-secret");
-    config.providers.insert(
+    config.backends.insert(
         "offline".to_owned(),
-        open_compute_core::AiProviderConfig {
-            base_url: "https://provider.invalid/v1".to_owned(),
+        open_compute_core::AiBackendConfig {
+            protocol: open_compute_core::AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: "https://provider.invalid/v1/embeddings".to_owned(),
             auth: AiAuthConfig::Bearer {
                 secret: open_compute_core::SecretReference {
                     env: None,
                     file: Some(missing_secret),
                 },
             },
+            headers: Default::default(),
         },
     );
     assert_eq!(

--- a/crates/service/src/support_bundle.rs
+++ b/crates/service/src/support_bundle.rs
@@ -293,7 +293,7 @@ pub(crate) fn search_summary(loaded: &LoadedConfig) -> Result<serde_json::Value,
         })
     };
     Ok(serde_json::json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "resource_count_bound": 10_000,
         "resources": {
             "vectorize_index": counts(BindingKind::VectorizeIndex),
@@ -303,16 +303,16 @@ pub(crate) fn search_summary(loaded: &LoadedConfig) -> Result<serde_json::Value,
         "contracts": {
             "vectorize_schema_version": VECTORIZE_SCHEMA_VERSION,
             "ai_search_schema_version": AI_SEARCH_SCHEMA_VERSION,
-            "ai_provider_contract_sha256": ai_provider_contract_sha256(loaded)?,
+            "ai_backend_catalog_sha256": ai_backend_catalog_sha256(loaded)?,
         }
     }))
 }
 
-fn ai_provider_contract_sha256(loaded: &LoadedConfig) -> Result<String, PlatformError> {
+fn ai_backend_catalog_sha256(loaded: &LoadedConfig) -> Result<String, PlatformError> {
     let config = &loaded.config.ai;
     config.validate()?;
     let mut digest = sha2::Sha256::new();
-    digest.update(b"open-compute/ai-provider-catalog/v1\0");
+    digest.update(b"open-compute/ai-backend-catalog/v2\0");
     for value in [
         u64::from(config.max_provider_in_flight),
         u64::from(config.max_embedding_inputs_per_batch),
@@ -339,10 +339,28 @@ fn ai_provider_contract_sha256(loaded: &LoadedConfig) -> Result<String, Platform
             .unwrap_or("")
             .as_bytes(),
     );
-    for (name, provider) in &config.providers {
+    for (name, backend) in &config.backends {
         digest_part(&mut digest, name.as_bytes());
-        digest_part(&mut digest, provider.base_url.as_bytes());
-        digest_part(&mut digest, provider.auth.kind_token().as_bytes());
+        digest_part(&mut digest, backend.protocol.as_str().as_bytes());
+        digest_part(&mut digest, backend.endpoint.as_bytes());
+        digest_part(&mut digest, backend.auth.kind_token().as_bytes());
+        digest_part(
+            &mut digest,
+            backend
+                .auth
+                .header_name()
+                .as_deref()
+                .unwrap_or("")
+                .as_bytes(),
+        );
+        let mut headers = backend
+            .headers
+            .iter()
+            .map(|(name, value)| (name.to_ascii_lowercase(), value))
+            .collect::<Vec<_>>();
+        headers.sort_by(|left, right| left.0.cmp(&right.0));
+        let headers = serde_json::to_vec(&headers).map_err(|_| bundle_invalid())?;
+        digest_part(&mut digest, &headers);
     }
     for alias in config.embedding_models.keys() {
         let contract = config.resolve_embedding_model(Some(alias))?;
@@ -405,9 +423,12 @@ fn secret_needles(loaded: &LoadedConfig) -> Result<Vec<Vec<u8>>, PlatformError> 
             .as_bytes()
             .to_vec(),
     );
-    for provider in loaded.config.ai.providers.values() {
-        if let AiAuthConfig::Bearer { secret } = &provider.auth {
-            values.push(resolve_admin_auth(secret)?.expose().as_bytes().to_vec());
+    for backend in loaded.config.ai.backends.values() {
+        match &backend.auth {
+            AiAuthConfig::Bearer { secret } | AiAuthConfig::Header { secret, .. } => {
+                values.push(resolve_admin_auth(secret)?.expose().as_bytes().to_vec());
+            }
+            AiAuthConfig::None => {}
         }
     }
     values.retain(|value| value.len() >= 4);

--- a/crates/service/src/tests/p1_capability_release_support_bundle_and_metrics_contract_is_bounded.rs
+++ b/crates/service/src/tests/p1_capability_release_support_bundle_and_metrics_contract_is_bounded.rs
@@ -135,12 +135,12 @@ async fn p1_capability_release_support_bundle_and_metrics_contract_is_bounded() 
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
     }));
     let search = crate::support_bundle::search_summary(&loaded).unwrap();
-    assert_eq!(search["schema_version"], 1);
+    assert_eq!(search["schema_version"], 2);
     assert_eq!(search["resources"]["vectorize_index"]["total"], 0);
     assert_eq!(search["resources"]["ai_search_namespace"]["total"], 0);
     assert_eq!(search["resources"]["ai_search_instance"]["total"], 0);
     assert_eq!(
-        search["contracts"]["ai_provider_contract_sha256"]
+        search["contracts"]["ai_backend_catalog_sha256"]
             .as_str()
             .unwrap()
             .len(),

--- a/crates/service/tests/ai_provider_contract.rs
+++ b/crates/service/tests/ai_provider_contract.rs
@@ -6,8 +6,9 @@ use axum::extract::State;
 use axum::http::{HeaderValue, Response, StatusCode};
 use axum::routing::post;
 use open_compute_core::{
-    AiAuthConfig, AiConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiGenerationCapability,
-    AiGenerationModelConfig, AiProviderConfig, AiTokenizer, AiTokenizerArtifactConfig,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiConfig, AiEmbeddingModelConfig,
+    AiEmbeddingProfileConfig, AiGenerationCapability, AiGenerationModelConfig, AiTokenizer,
+    AiTokenizerArtifactConfig, AiTokenizerConfig,
 };
 use open_compute_service::ai_provider::{
     AiProviderError, ChatMessage, OpenAiChatClient, OpenAiProviderClient,
@@ -165,38 +166,58 @@ async fn client(
         query_timeout_ms: timeout_ms,
         ..AiConfig::default()
     };
-    config.providers.insert(
-        "fixture".into(),
-        AiProviderConfig {
-            base_url: format!("http://127.0.0.1:{port}/v1"),
+    config.backends.insert(
+        "fixture-embeddings".into(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: format!("http://127.0.0.1:{port}/v1/embeddings"),
             auth: AiAuthConfig::None,
+            headers: Default::default(),
+        },
+    );
+    config.backends.insert(
+        "fixture-chat".into(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiChatCompletionsV1,
+            endpoint: format!("http://127.0.0.1:{port}/v1/chat/completions"),
+            auth: AiAuthConfig::None,
+            headers: Default::default(),
+        },
+    );
+    let profile = "fixture/qwen3";
+    config.embedding_profiles.insert(
+        profile.into(),
+        AiEmbeddingProfileConfig {
+            dimensions: 1_024,
+            max_input_tokens: 8_192,
+            send_dimensions: false,
+            tokenizer: AiTokenizerConfig {
+                kind: AiTokenizer::Qwen3,
+                revision: "fixture-tokenizer-revision".into(),
+                artifact: AiTokenizerArtifactConfig {
+                    path: "/opt/open-compute/models/qwen3/tokenizer.json".into(),
+                    sha256: "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"
+                        .into(),
+                },
+            },
         },
     );
     config.embedding_models.insert(
         ALIAS.into(),
         AiEmbeddingModelConfig {
-            provider: "fixture".into(),
+            backend: "fixture-embeddings".into(),
             remote_model: ALIAS.into(),
-            model_revision: "fixture-revision".into(),
-            dimensions: 1024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "fixture-tokenizer-revision".into(),
-            tokenizer_artifact: AiTokenizerArtifactConfig {
-                path: "/opt/open-compute/models/qwen3/tokenizer.json".into(),
-                sha256: "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a".into(),
-            },
+            provider_revision: Some("fixture-revision".into()),
+            profile: profile.into(),
         },
     );
     config.default_embedding_model = Some(ALIAS.into());
     config.generation_models.insert(
         "fixture/generation".into(),
         AiGenerationModelConfig {
-            provider: "fixture".into(),
+            backend: "fixture-chat".into(),
             remote_model: "fixture-chat".into(),
-            model_revision: "fixture-chat-revision".into(),
+            provider_revision: Some("fixture-chat-revision".into()),
             max_context_tokens: 4_096,
             capabilities: BTreeSet::from([
                 AiGenerationCapability::Chat,

--- a/crates/service/tests/p1_snapshot_restore/p5_search.rs
+++ b/crates/service/tests/p1_snapshot_restore/p5_search.rs
@@ -1,5 +1,8 @@
 use open_compute_artifacts::{AiSearchObjectRef, AiSearchObjectStore};
-use open_compute_core::{BindingKind, RequestId, ResourceId};
+use open_compute_core::{
+    AiEmbeddingMetric, AiTokenizer, BindingKind, RequestId, ResolvedEmbeddingModelContract,
+    ResourceId,
+};
 use open_compute_storage::{
     AI_SEARCH_SCHEMA_VERSION, AiSearchCatalog, AiSearchInstanceStorageContract, AiSearchPaths,
     AiSearchStore, NewAiSearchItemGeneration, PlatformStorage, StagedAiSearchChunk,
@@ -19,6 +22,36 @@ pub(super) struct P5SnapshotFixture {
     pub(super) ai_search_id: ResourceId,
     pub(super) object: AiSearchObjectRef,
     pub(super) object_key: String,
+}
+
+fn model_contract() -> Vec<u8> {
+    let digest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let mut contract = ResolvedEmbeddingModelContract {
+        embedding_alias: "fixture/snapshot".to_owned(),
+        backend_name: "snapshot".to_owned(),
+        backend_contract_sha256: digest.to_owned(),
+        protocol: "openai_embeddings_v1".to_owned(),
+        endpoint_sha256: digest.to_owned(),
+        auth_kind: "none".to_owned(),
+        auth_header_name: None,
+        headers_sha256: digest.to_owned(),
+        remote_model: "snapshot".to_owned(),
+        provider_revision: None,
+        profile: "fixture/snapshot".to_owned(),
+        profile_contract_sha256: digest.to_owned(),
+        dimensions: 1,
+        send_dimensions: false,
+        metric: AiEmbeddingMetric::Cosine,
+        max_input_tokens: 512,
+        tokenizer: AiTokenizer::Qwen3,
+        tokenizer_revision: "snapshot".to_owned(),
+        tokenizer_artifact_sha256: digest.to_owned(),
+        contract_sha256: String::new(),
+    };
+    contract.contract_sha256 = hex::encode(Sha256::digest(
+        serde_json::to_vec(&contract).expect("serialize unsigned snapshot contract"),
+    ));
+    serde_json::to_vec(&contract).expect("serialize snapshot contract")
 }
 
 pub(super) async fn seed(
@@ -66,7 +99,7 @@ pub(super) async fn seed(
         .expect("apply Vectorize fixture");
 
     let namespace_id = create_namespace(storage, account);
-    let model_contract_json = br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"snapshot","tokenizerArtifactSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#.to_vec();
+    let model_contract_json = model_contract();
     let model_contract_sha256 = Sha256::digest(&model_contract_json).into();
     let public_config_json = br#"{"chunk":true,"chunk_overlap":0,"chunk_size":64,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#.to_vec();
     let ai_search_id = create_instance(

--- a/crates/service/tests/p5_search_gate.rs
+++ b/crates/service/tests/p5_search_gate.rs
@@ -12,10 +12,11 @@ use open_compute_artifacts::{
     resolve_s3_credentials_with,
 };
 use open_compute_core::{
-    AiAuthConfig, AiConfig, AiEmbeddingMetric, AiEmbeddingModelConfig, AiGenerationCapability,
-    AiGenerationModelConfig, AiProviderConfig, AiTokenizer, AiTokenizerArtifactConfig, BindingKind,
-    CacheConfig, CanonicalBindingConfig, CanonicalPermissions, DataConfig, DocumentParserConfig,
-    PlatformConfig, Redactor, RequestId, RuntimeConfig, SecretReference, StartupId, SystemClock,
+    AiAuthConfig, AiBackendConfig, AiBackendProtocol, AiConfig, AiEmbeddingModelConfig,
+    AiEmbeddingProfileConfig, AiGenerationCapability, AiGenerationModelConfig, AiTokenizer,
+    AiTokenizerArtifactConfig, AiTokenizerConfig, BindingKind, CacheConfig, CanonicalBindingConfig,
+    CanonicalPermissions, DataConfig, DocumentParserConfig, PlatformConfig, Redactor, RequestId,
+    RuntimeConfig, SecretReference, StartupId, SystemClock,
 };
 use open_compute_runtime::{
     DirectoryServicePath, ExternalServiceAddress, GenerationAuthRegistry, OsJitter,

--- a/crates/service/tests/p5_search_gate/support.rs
+++ b/crates/service/tests/p5_search_gate/support.rs
@@ -289,47 +289,59 @@ pub(super) fn ai_config(
 ) -> AiConfig {
     let mut config = AiConfig::default();
     let (tokenizer_path, tokenizer_sha256) = tokenizer_artifact();
-    config.providers.insert(
-        "fixture".to_owned(),
-        AiProviderConfig {
-            base_url: embedding_base_url.to_owned(),
+    config.backends.insert(
+        "fixture-embeddings".to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiEmbeddingsV1,
+            endpoint: format!("{}/embeddings", embedding_base_url.trim_end_matches('/')),
             auth: AiAuthConfig::Bearer {
                 secret: embedding_secret(secret_root),
             },
+            headers: BTreeMap::new(),
         },
     );
-    config.providers.insert(
+    config.backends.insert(
         "chat-fixture".to_owned(),
-        AiProviderConfig {
-            base_url: chat_base_url.to_owned(),
+        AiBackendConfig {
+            protocol: AiBackendProtocol::OpenAiChatCompletionsV1,
+            endpoint: format!("{}/chat/completions", chat_base_url.trim_end_matches('/')),
             auth: AiAuthConfig::None,
+            headers: BTreeMap::new(),
+        },
+    );
+    let profile = "fixture/qwen3";
+    config.embedding_profiles.insert(
+        profile.to_owned(),
+        AiEmbeddingProfileConfig {
+            dimensions: 1_024,
+            max_input_tokens: 8_192,
+            send_dimensions: false,
+            tokenizer: AiTokenizerConfig {
+                kind: AiTokenizer::Qwen3,
+                revision: "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned(),
+                artifact: AiTokenizerArtifactConfig {
+                    path: tokenizer_path,
+                    sha256: tokenizer_sha256,
+                },
+            },
         },
     );
     config.embedding_models.insert(
         EMBEDDING_ALIAS.to_owned(),
         AiEmbeddingModelConfig {
-            provider: "fixture".to_owned(),
+            backend: "fixture-embeddings".to_owned(),
             remote_model: EMBEDDING_ALIAS.to_owned(),
-            model_revision: "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned(),
-            dimensions: 1_024,
-            request_dimensions: None,
-            metric: AiEmbeddingMetric::Cosine,
-            max_input_tokens: 8_192,
-            tokenizer: AiTokenizer::Qwen3,
-            tokenizer_revision: "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned(),
-            tokenizer_artifact: AiTokenizerArtifactConfig {
-                path: tokenizer_path,
-                sha256: tokenizer_sha256,
-            },
+            provider_revision: Some("97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3".to_owned()),
+            profile: profile.to_owned(),
         },
     );
     config.default_embedding_model = Some(EMBEDDING_ALIAS.to_owned());
     config.generation_models.insert(
         GENERATION_ALIAS.to_owned(),
         AiGenerationModelConfig {
-            provider: "chat-fixture".to_owned(),
+            backend: "chat-fixture".to_owned(),
             remote_model: "fixture-chat".to_owned(),
-            model_revision: "fixture-chat-revision".to_owned(),
+            provider_revision: Some("fixture-chat-revision".to_owned()),
             max_context_tokens: 4_096,
             capabilities: BTreeSet::from([
                 AiGenerationCapability::Chat,

--- a/crates/service/tests/p6_wrangler_resource_gate/search.rs
+++ b/crates/service/tests/p6_wrangler_resource_gate/search.rs
@@ -53,22 +53,26 @@ pub(super) fn ai_config_toml(embedding_base_url: &str) -> String {
         r#"[ai]
 default_embedding_model = "{EMBEDDING_ALIAS}"
 
-[ai.providers.resource-gate]
-base_url = {embedding_base_url}
+[ai.backends.resource-gate]
+protocol = "openai_embeddings_v1"
+endpoint = {embedding_endpoint}
 auth = {{ kind = "none" }}
 
-[ai.embedding_models."{EMBEDDING_ALIAS}"]
-provider = "resource-gate"
-remote_model = "{EMBEDDING_ALIAS}"
-model_revision = "fixed-wrangler-resource-gate"
+[ai.embedding_profiles."resource-gate/qwen3"]
 dimensions = 1024
-metric = "cosine"
 max_input_tokens = 8192
-tokenizer = "qwen3"
-tokenizer_revision = "fixed-wrangler-resource-gate"
-tokenizer_artifact = {{ path = {tokenizer_path}, sha256 = "{tokenizer_sha256}" }}
+tokenizer = {{ kind = "qwen3", revision = "fixed-wrangler-resource-gate", artifact = {{ path = {tokenizer_path}, sha256 = "{tokenizer_sha256}" }} }}
+
+[ai.embedding_models."{EMBEDDING_ALIAS}"]
+backend = "resource-gate"
+remote_model = "{EMBEDDING_ALIAS}"
+provider_revision = "fixed-wrangler-resource-gate"
+profile = "resource-gate/qwen3"
 "#,
-        embedding_base_url = toml::Value::String(embedding_base_url.to_owned()),
+        embedding_endpoint = toml::Value::String(format!(
+            "{}/embeddings",
+            embedding_base_url.trim_end_matches('/')
+        )),
         tokenizer_path = toml::Value::String(tokenizer_path.display().to_string()),
         tokenizer_sha256 = hex::encode(Sha256::digest(tokenizer)),
     )

--- a/crates/storage/src/ai_search/contract.rs
+++ b/crates/storage/src/ai_search/contract.rs
@@ -1,0 +1,176 @@
+use super::AiSearchInstanceStorageContract;
+use open_compute_core::{
+    AiEmbeddingMetric, ResolvedEmbeddingModelContract, ResolvedTokenizerContract,
+};
+use sha2::{Digest as _, Sha256};
+
+pub(super) fn valid_instance_contract(contract: &AiSearchInstanceStorageContract<'_>) -> bool {
+    if contract.public_config_json.len() > 65_536 || contract.model_contract_json.len() > 65_536 {
+        return false;
+    }
+    let Ok(public) = serde_json::from_slice::<serde_json::Value>(contract.public_config_json)
+    else {
+        return false;
+    };
+    let Ok(model) = serde_json::from_slice::<serde_json::Value>(contract.model_contract_json)
+    else {
+        return false;
+    };
+    let Some(public) = public.as_object() else {
+        return false;
+    };
+    let index = public
+        .get("index_method")
+        .and_then(serde_json::Value::as_object);
+    let vector = index
+        .and_then(|index| index.get("vector"))
+        .and_then(serde_json::Value::as_bool);
+    let keyword = index
+        .and_then(|index| index.get("keyword"))
+        .and_then(serde_json::Value::as_bool);
+    let valid_public = vector == Some(contract.vector_enabled)
+        && keyword == Some(contract.keyword_enabled)
+        && public
+            .get("chunk")
+            .is_some_and(serde_json::Value::is_boolean)
+        && public
+            .get("chunk_size")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|value| value > 0)
+        && public
+            .get("chunk_overlap")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|value| value <= 30)
+        && public
+            .get("score_threshold")
+            .and_then(serde_json::Value::as_f64)
+            .is_some_and(|value| value.is_finite() && (0.0..=1.0).contains(&value))
+        && public
+            .get("max_num_results")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|value| (1..=50).contains(&value))
+        && public
+            .get("fusion_method")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| matches!(value, "max" | "rrf"))
+        && public
+            .get("custom_metadata")
+            .is_some_and(serde_json::Value::is_array)
+        && public
+            .get("metadata")
+            .is_some_and(serde_json::Value::is_object);
+    if !valid_public {
+        return false;
+    }
+    if contract.vector_enabled {
+        serde_json::from_value::<ResolvedEmbeddingModelContract>(model)
+            .is_ok_and(|model| valid_embedding_contract(&model, contract.dimensions))
+    } else {
+        let Some(model) = model.as_object() else {
+            return false;
+        };
+        model.get("kind").and_then(serde_json::Value::as_str) == Some("keyword_only")
+            && model
+                .get("schemaVersion")
+                .and_then(serde_json::Value::as_u64)
+                == Some(1)
+            && model
+                .get("tokenizerContract")
+                .and_then(serde_json::Value::as_object)
+                .cloned()
+                .and_then(|tokenizer| {
+                    serde_json::from_value::<ResolvedTokenizerContract>(serde_json::Value::Object(
+                        tokenizer,
+                    ))
+                    .ok()
+                })
+                .is_some_and(|tokenizer| valid_tokenizer_contract(&tokenizer))
+    }
+}
+
+fn valid_embedding_contract(model: &ResolvedEmbeddingModelContract, dimensions: u32) -> bool {
+    model.dimensions == dimensions
+        && model.metric == AiEmbeddingMetric::Cosine
+        && model.max_input_tokens > 0
+        && nonempty(&model.embedding_alias)
+        && nonempty(&model.backend_name)
+        && valid_sha256(&model.backend_contract_sha256)
+        && model.protocol == "openai_embeddings_v1"
+        && valid_sha256(&model.endpoint_sha256)
+        && valid_auth_shape(model)
+        && valid_sha256(&model.headers_sha256)
+        && nonempty(&model.remote_model)
+        && model.provider_revision.as_deref().is_none_or(nonempty)
+        && nonempty(&model.profile)
+        && valid_sha256(&model.profile_contract_sha256)
+        && nonempty(&model.tokenizer_revision)
+        && valid_sha256(&model.tokenizer_artifact_sha256)
+        && valid_embedded_contract_digest(model)
+}
+
+fn valid_tokenizer_contract(contract: &ResolvedTokenizerContract) -> bool {
+    contract.max_input_tokens > 0
+        && nonempty(&contract.embedding_alias)
+        && nonempty(&contract.profile)
+        && valid_sha256(&contract.profile_contract_sha256)
+        && nonempty(&contract.tokenizer_revision)
+        && valid_sha256(&contract.tokenizer_artifact_sha256)
+        && valid_embedded_contract_digest(contract)
+}
+
+fn valid_auth_shape(model: &ResolvedEmbeddingModelContract) -> bool {
+    match model.auth_kind.as_str() {
+        "bearer" | "none" => model.auth_header_name.is_none(),
+        "header" => model.auth_header_name.as_deref().is_some_and(nonempty),
+        _ => false,
+    }
+}
+
+fn valid_embedded_contract_digest<T>(contract: &T) -> bool
+where
+    T: serde::Serialize + Clone + EmbeddedContractDigest,
+{
+    let claimed = contract.contract_sha256();
+    if !valid_sha256(claimed) {
+        return false;
+    }
+    let mut unsigned = contract.clone();
+    unsigned.clear_contract_sha256();
+    serde_json::to_vec(&unsigned).is_ok_and(|bytes| hex::encode(Sha256::digest(bytes)) == claimed)
+}
+
+trait EmbeddedContractDigest {
+    fn contract_sha256(&self) -> &str;
+    fn clear_contract_sha256(&mut self);
+}
+
+impl EmbeddedContractDigest for ResolvedEmbeddingModelContract {
+    fn contract_sha256(&self) -> &str {
+        &self.contract_sha256
+    }
+
+    fn clear_contract_sha256(&mut self) {
+        self.contract_sha256.clear();
+    }
+}
+
+impl EmbeddedContractDigest for ResolvedTokenizerContract {
+    fn contract_sha256(&self) -> &str {
+        &self.contract_sha256
+    }
+
+    fn clear_contract_sha256(&mut self) {
+        self.contract_sha256.clear();
+    }
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn nonempty(value: &str) -> bool {
+    !value.is_empty()
+}

--- a/crates/storage/src/ai_search/mod.rs
+++ b/crates/storage/src/ai_search/mod.rs
@@ -3,6 +3,7 @@
 mod batch;
 mod catalog;
 mod config;
+mod contract;
 mod ingest_gc;
 mod inspection;
 mod jobs;
@@ -20,6 +21,7 @@ pub use model::{
 };
 pub use paths::AiSearchPaths;
 
+use contract::valid_instance_contract;
 use open_compute_core::{ErrorCode, PlatformError};
 use rand::TryRngCore as _;
 use rusqlite::{Connection, OpenFlags, OptionalExtension as _, TransactionBehavior, params};
@@ -625,131 +627,6 @@ fn canonical_json_object(bytes: &[u8], max_bytes: usize) -> bool {
         return false;
     };
     serde_json::to_vec(&object).is_ok_and(|canonical| canonical == bytes)
-}
-
-fn valid_instance_contract(contract: &AiSearchInstanceStorageContract<'_>) -> bool {
-    if contract.public_config_json.len() > 65_536 || contract.model_contract_json.len() > 65_536 {
-        return false;
-    }
-    let Ok(public) = serde_json::from_slice::<serde_json::Value>(contract.public_config_json)
-    else {
-        return false;
-    };
-    let Ok(model) = serde_json::from_slice::<serde_json::Value>(contract.model_contract_json)
-    else {
-        return false;
-    };
-    let Some(public) = public.as_object() else {
-        return false;
-    };
-    let index = public
-        .get("index_method")
-        .and_then(serde_json::Value::as_object);
-    let vector = index
-        .and_then(|index| index.get("vector"))
-        .and_then(serde_json::Value::as_bool);
-    let keyword = index
-        .and_then(|index| index.get("keyword"))
-        .and_then(serde_json::Value::as_bool);
-    let valid_public = vector == Some(contract.vector_enabled)
-        && keyword == Some(contract.keyword_enabled)
-        && public
-            .get("chunk")
-            .is_some_and(serde_json::Value::is_boolean)
-        && public
-            .get("chunk_size")
-            .and_then(serde_json::Value::as_u64)
-            .is_some_and(|value| value > 0)
-        && public
-            .get("chunk_overlap")
-            .and_then(serde_json::Value::as_u64)
-            .is_some_and(|value| value <= 30)
-        && public
-            .get("score_threshold")
-            .and_then(serde_json::Value::as_f64)
-            .is_some_and(|value| value.is_finite() && (0.0..=1.0).contains(&value))
-        && public
-            .get("max_num_results")
-            .and_then(serde_json::Value::as_u64)
-            .is_some_and(|value| (1..=50).contains(&value))
-        && public
-            .get("fusion_method")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| matches!(value, "max" | "rrf"))
-        && public
-            .get("custom_metadata")
-            .is_some_and(serde_json::Value::is_array)
-        && public
-            .get("metadata")
-            .is_some_and(serde_json::Value::is_object);
-    if !valid_public {
-        return false;
-    }
-    let Some(model) = model.as_object() else {
-        return false;
-    };
-    if contract.vector_enabled {
-        model.get("dimensions").and_then(serde_json::Value::as_u64)
-            == Some(u64::from(contract.dimensions))
-            && model.get("metric").and_then(serde_json::Value::as_str) == Some("cosine")
-            && model
-                .get("tokenizer")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.is_empty())
-            && model
-                .get("tokenizerRevision")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.is_empty())
-            && model
-                .get("tokenizerArtifactSha256")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| {
-                    value.len() == 64
-                        && value
-                            .bytes()
-                            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-                })
-    } else {
-        model.get("kind").and_then(serde_json::Value::as_str) == Some("keyword_only")
-            && model
-                .get("schemaVersion")
-                .and_then(serde_json::Value::as_u64)
-                == Some(1)
-            && model
-                .get("tokenizerContract")
-                .and_then(serde_json::Value::as_object)
-                .is_some_and(|tokenizer| {
-                    tokenizer
-                        .get("embeddingAlias")
-                        .and_then(serde_json::Value::as_str)
-                        .is_some_and(|value| !value.is_empty())
-                        && tokenizer
-                            .get("tokenizer")
-                            .and_then(serde_json::Value::as_str)
-                            .is_some_and(|value| !value.is_empty())
-                        && tokenizer
-                            .get("tokenizerRevision")
-                            .and_then(serde_json::Value::as_str)
-                            .is_some_and(|value| !value.is_empty())
-                        && tokenizer
-                            .get("tokenizerArtifactSha256")
-                            .and_then(serde_json::Value::as_str)
-                            .is_some_and(|value| {
-                                value.len() == 64
-                                    && value.bytes().all(|byte| {
-                                        byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
-                                    })
-                            })
-                        && tokenizer
-                            .get("maxInputTokens")
-                            .and_then(serde_json::Value::as_u64)
-                            .is_some_and(|value| value > 0)
-                        && tokenizer
-                            .get("contractSha256")
-                            .and_then(serde_json::Value::as_str)
-                            .is_some_and(|value| !value.is_empty())
-                })
-    }
 }
 
 fn to_i64(value: u64) -> Result<i64, PlatformError> {

--- a/crates/storage/src/ai_search/tests.rs
+++ b/crates/storage/src/ai_search/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use open_compute_core::{AiEmbeddingMetric, ResolvedEmbeddingModelContract};
 
 #[path = "catalog_tests.rs"]
 mod catalog_tests;
@@ -22,16 +23,45 @@ fn new_item<'a>(metadata: &'a [u8]) -> NewAiSearchItemGeneration<'a> {
     }
 }
 
+fn model_contract(tokenizer_revision: &str) -> Vec<u8> {
+    let digest = "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a";
+    let mut contract = ResolvedEmbeddingModelContract {
+        embedding_alias: "fixture/embed".to_owned(),
+        backend_name: "fixture-embeddings".to_owned(),
+        backend_contract_sha256: digest.to_owned(),
+        protocol: "openai_embeddings_v1".to_owned(),
+        endpoint_sha256: digest.to_owned(),
+        auth_kind: "bearer".to_owned(),
+        auth_header_name: None,
+        headers_sha256: digest.to_owned(),
+        remote_model: "fixture-remote-model".to_owned(),
+        provider_revision: None,
+        profile: "fixture/profile".to_owned(),
+        profile_contract_sha256: digest.to_owned(),
+        dimensions: 1,
+        send_dimensions: false,
+        metric: AiEmbeddingMetric::Cosine,
+        max_input_tokens: 1_024,
+        tokenizer: open_compute_core::AiTokenizer::Qwen3,
+        tokenizer_revision: tokenizer_revision.to_owned(),
+        tokenizer_artifact_sha256: digest.to_owned(),
+        contract_sha256: String::new(),
+    };
+    contract.contract_sha256 = hex::encode(Sha256::digest(
+        serde_json::to_vec(&contract).expect("serialize unsigned model contract"),
+    ));
+    serde_json::to_vec(&contract).expect("serialize model contract")
+}
+
 fn store(path: &Path) -> AiSearchStore {
-    let model_contract_json =
-        br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#;
-    let model_contract_sha256 = Sha256::digest(model_contract_json).into();
+    let model_contract_json = model_contract("rev");
+    let model_contract_sha256 = Sha256::digest(&model_contract_json).into();
     AiSearchStore::open(
         path,
         &AiSearchInstanceStorageContract {
             resource_id: "instance-1",
             model_contract_sha256,
-            model_contract_json,
+            model_contract_json: &model_contract_json,
             public_config_json: br#"{"chunk":true,"chunk_overlap":10,"chunk_size":1,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#,
             dimensions: 1,
             vector_enabled: true,
@@ -57,6 +87,59 @@ fn storage_key_resolves_before_instance_directory_exists() {
         .expect("resolve unpublished instance");
     assert_eq!(path, paths.instance_path(account, resource));
     assert!(path.parent().is_some_and(|parent| !parent.exists()));
+}
+
+#[test]
+fn model_contract_shape_and_embedded_digest_fail_closed() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let public = br#"{"chunk":true,"chunk_overlap":10,"chunk_size":1,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#;
+
+    let mut missing_backend: serde_json::Value =
+        serde_json::from_slice(&model_contract("rev")).expect("model JSON");
+    missing_backend
+        .as_object_mut()
+        .expect("model object")
+        .remove("backendName");
+    let missing_backend = serde_json::to_vec(&missing_backend).expect("model bytes");
+    let missing_contract = AiSearchInstanceStorageContract {
+        resource_id: "instance-1",
+        model_contract_sha256: Sha256::digest(&missing_backend).into(),
+        model_contract_json: &missing_backend,
+        public_config_json: public,
+        dimensions: 1,
+        vector_enabled: true,
+        keyword_enabled: true,
+    };
+    assert_eq!(
+        AiSearchStore::open(
+            &directory.path().join("missing.sqlite"),
+            &missing_contract,
+            1,
+        )
+        .unwrap_err()
+        .code(),
+        ErrorCode::ResourceInvariantViolation
+    );
+
+    let mut forged: serde_json::Value =
+        serde_json::from_slice(&model_contract("rev")).expect("model JSON");
+    forged["contractSha256"] = serde_json::Value::String("0".repeat(64));
+    let forged = serde_json::to_vec(&forged).expect("model bytes");
+    let forged_contract = AiSearchInstanceStorageContract {
+        resource_id: "instance-1",
+        model_contract_sha256: Sha256::digest(&forged).into(),
+        model_contract_json: &forged,
+        public_config_json: public,
+        dimensions: 1,
+        vector_enabled: true,
+        keyword_enabled: true,
+    };
+    assert_eq!(
+        AiSearchStore::open(&directory.path().join("forged.sqlite"), &forged_contract, 1,)
+            .unwrap_err()
+            .code(),
+        ErrorCode::ResourceInvariantViolation
+    );
 }
 
 #[test]
@@ -229,10 +312,7 @@ fn readonly_instance_inspection_validates_identity_and_contract() {
     store
         .enqueue_item_generation("job-1", &new_item(b"{}"))
         .expect("enqueue");
-    let expected: [u8; 32] = Sha256::digest(
-        br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#,
-    )
-    .into();
+    let expected: [u8; 32] = Sha256::digest(model_contract("rev")).into();
     let authority = inspect_ai_search_instance(&path, "instance-1", expected, 100)
         .expect("readonly inspection");
     assert_eq!(authority.dimensions, 1);
@@ -262,15 +342,14 @@ fn identity_and_metadata_mismatch_fail_closed() {
         ErrorCode::LimitInvalid
     );
     drop(store);
-    let model_contract_json =
-        br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#;
+    let model_contract_json = model_contract("rev");
     assert_eq!(
         AiSearchStore::open(
             &path,
             &AiSearchInstanceStorageContract {
                 resource_id: "instance-2",
-                model_contract_sha256: Sha256::digest(model_contract_json).into(),
-                model_contract_json,
+                model_contract_sha256: Sha256::digest(&model_contract_json).into(),
+                model_contract_json: &model_contract_json,
                 public_config_json: br#"{"chunk":true,"chunk_overlap":10,"chunk_size":1,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#,
                 dimensions: 1,
                 vector_enabled: true,
@@ -406,12 +485,12 @@ fn full_reindex_is_generation_fenced_and_survives_reopen() {
             .activate_item_generation(&claim, "item-1", 1, &initial, 11)
             .unwrap()
     );
-    let model = br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#;
+    let model = model_contract("rev");
     let public = br#"{"chunk":true,"chunk_overlap":0,"chunk_size":1,"custom_metadata":[{"data_type":"text","field_name":"language"}],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#;
     let contract = AiSearchInstanceStorageContract {
         resource_id: "instance-1",
-        model_contract_sha256: Sha256::digest(model).into(),
-        model_contract_json: model,
+        model_contract_sha256: Sha256::digest(&model).into(),
+        model_contract_json: &model,
         public_config_json: public,
         dimensions: 1,
         vector_enabled: true,
@@ -621,8 +700,8 @@ fn failed_full_reindex_restores_old_contract_and_active_chunks() {
             .activate_item_generation(&initial_claim, "item-1", 1, &initial, 11)
             .unwrap()
     );
-    let replacement_model = br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev2","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#;
-    let replacement_digest: [u8; 32] = Sha256::digest(replacement_model).into();
+    let replacement_model = model_contract("rev2");
+    let replacement_digest: [u8; 32] = Sha256::digest(&replacement_model).into();
     let replacement_public = br#"{"chunk":true,"chunk_overlap":0,"chunk_size":1,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#;
     assert!(
         store
@@ -631,7 +710,7 @@ fn failed_full_reindex_restores_old_contract_and_active_chunks() {
                 &AiSearchInstanceStorageContract {
                     resource_id: "instance-1",
                     model_contract_sha256: replacement_digest,
-                    model_contract_json: replacement_model,
+                    model_contract_json: &replacement_model,
                     public_config_json: replacement_public,
                     dimensions: 1,
                     vector_enabled: true,
@@ -664,15 +743,15 @@ fn failed_full_reindex_preserves_non_null_desired_generation_without_active_cont
     store
         .enqueue_item_generation("job-1", &new_item(b"{}"))
         .expect("enqueue");
-    let replacement_model = br#"{"dimensions":1,"metric":"cosine","tokenizer":"qwen3","tokenizerRevision":"rev2","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a"}"#;
+    let replacement_model = model_contract("rev2");
     assert!(
         store
             .begin_full_reindex(
                 1,
                 &AiSearchInstanceStorageContract {
                     resource_id: "instance-1",
-                    model_contract_sha256: Sha256::digest(replacement_model).into(),
-                    model_contract_json: replacement_model,
+                    model_contract_sha256: Sha256::digest(&replacement_model).into(),
+                    model_contract_json: &replacement_model,
                     public_config_json: br#"{"chunk":true,"chunk_overlap":0,"chunk_size":1,"custom_metadata":[],"fusion_method":"rrf","index_method":{"keyword":true,"vector":true},"max_num_results":10,"metadata":{},"score_threshold":0.4}"#,
                     dimensions: 1,
                     vector_enabled: true,

--- a/crates/workers/src/ai_search_tests.rs
+++ b/crates/workers/src/ai_search_tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::{CreateResourceOutcome, CreateResourceRequest, ResourceController, ResourcePins};
 use open_compute_core::config::DataConfig;
-use open_compute_core::{ErrorCode, RequestId, SystemClock};
+use open_compute_core::{
+    AiTokenizer, ErrorCode, RequestId, ResolvedTokenizerContract, SystemClock,
+};
 use open_compute_storage::ResourceRepository;
 use sha2::{Digest as _, Sha256};
 use std::time::Duration;
@@ -56,9 +58,32 @@ fn record(
     }
 }
 
+fn keyword_model_contract() -> Vec<u8> {
+    let digest = "def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a";
+    let mut contract = ResolvedTokenizerContract {
+        embedding_alias: "@cf/qwen/qwen3-embedding-0.6b".to_owned(),
+        profile: "fixture/qwen3".to_owned(),
+        profile_contract_sha256: digest.to_owned(),
+        tokenizer: AiTokenizer::Qwen3,
+        tokenizer_revision: "fixture".to_owned(),
+        tokenizer_artifact_sha256: digest.to_owned(),
+        max_input_tokens: 8_192,
+        contract_sha256: String::new(),
+    };
+    contract.contract_sha256 = hex::encode(Sha256::digest(
+        serde_json::to_vec(&contract).expect("serialize unsigned tokenizer contract"),
+    ));
+    serde_json::to_vec(&serde_json::json!({
+        "kind": "keyword_only",
+        "schemaVersion": 1,
+        "tokenizerContract": contract,
+    }))
+    .expect("serialize keyword model contract")
+}
+
 fn spec(namespace_resource_id: ResourceId) -> AiSearchInstanceSpec {
     let public_config_json = br#"{"chunk":true,"chunk_overlap":15,"chunk_size":512,"custom_metadata":[],"fusion_method":"max","id":"docs","index_method":{"keyword":true,"vector":false},"max_num_results":10,"metadata":{},"score_threshold":0.3}"#.to_vec();
-    let model_contract_json = br#"{"kind":"keyword_only","schemaVersion":1,"tokenizerContract":{"embeddingAlias":"@cf/qwen/qwen3-embedding-0.6b","tokenizer":"qwen3","tokenizerRevision":"fixture","tokenizerArtifactSha256":"def76fb086971c7867b829c23a26261e38d9d74e02139253b38aeb9df8b4b50a","maxInputTokens":8192,"contractSha256":"fixture"}}"#.to_vec();
+    let model_contract_json = keyword_model_contract();
     let model_contract_sha256 = Sha256::digest(&model_contract_json).into();
     AiSearchInstanceSpec {
         namespace_resource_id,

--- a/docs/acceptance/p5-release-acceptance.md
+++ b/docs/acceptance/p5-release-acceptance.md
@@ -2,7 +2,8 @@
 
 状态：active，2026-09-02。核心实现与本地证据见
 [Vectorize / AI Search](../implemented/p5-vectorize-ai-search.md)和
-[Xberg 文档解析](../implemented/p5-7-xberg-document-parsing.md)。
+[P5.1 Xberg 文档解析](../implemented/p5-1-xberg-document-parsing.md)、
+[P5.2 AI provider backend/profile](../implemented/p5-2-ai-provider-profiles.md)。
 
 ## 剩余 Gate
 

--- a/docs/implemented/README.md
+++ b/docs/implemented/README.md
@@ -20,7 +20,7 @@
 | P2.1–P2.5 | [Scheduler](p2-1-scheduler-hardening.md)、[Producer](p2-2-queue-producer.md)、[Consumer/Cron](p2-3-queue-consumer-cron.md)、[Workflow](p2-4-workflow-core.md)、[持久等待](p2-5-workflow-durable-waiting.md) |
 | P3.0–P3.4 | [Runtime 兼容](p3-0-cloudflare-runtime-compatibility.md)、[Assets](p3-1-static-assets.md)、[Service Binding](p3-2-service-bindings.md)、[Cache/Images](p3-3-workers-cache-images.md)、[Conformance](p3-4-cloudflare-conformance.md) |
 | P4 Next.js/vinext | [p4-nextjs-vinext-qualification.md](p4-nextjs-vinext-qualification.md)、[P4.0 调查](p4-nextjs-vinext-p4-0-results.md) |
-| P5 Vectorize/AI Search | [p5-vectorize-ai-search.md](p5-vectorize-ai-search.md)、[文档解析](p5-7-xberg-document-parsing.md) |
+| P5 Vectorize/AI Search | [p5-vectorize-ai-search.md](p5-vectorize-ai-search.md)、[P5.1 文档解析](p5-1-xberg-document-parsing.md)、[P5.2 AI provider backend/profile](p5-2-ai-provider-profiles.md) |
 | P6 v4 管理面 | [p6-cloudflare-v4-wrangler-compatibility.md](p6-cloudflare-v4-wrangler-compatibility.md) |
 | P7 Logs/Tail | [p7-workers-logs-realtime-tail.md](p7-workers-logs-realtime-tail.md) |
 | P8 Local/S3 | [p8-local-s3-object-backend.md](p8-local-s3-object-backend.md) |

--- a/docs/implemented/p5-1-xberg-document-parsing.md
+++ b/docs/implemented/p5-1-xberg-document-parsing.md
@@ -1,4 +1,4 @@
-# P5.7：PDF／Office 文档解析
+# P5.1：PDF／Office 文档解析
 
 状态：**implemented（2026-09-02）**。本地核心完成；跨平台、完整 parser fault/soak 和 hosted rich-document differential 见
 [P5 资格](../acceptance/p5-release-acceptance.md)。

--- a/docs/implemented/p5-2-ai-provider-profiles.md
+++ b/docs/implemented/p5-2-ai-provider-profiles.md
@@ -1,0 +1,210 @@
+# P5.2：AI provider backend 与 embedding profile
+
+状态：**implemented（2026-09-11）**。本方案解决
+[#41](https://github.com/elliothux/open-compute/issues/41)，并直接替换当前把 provider、固定 `/v1` root、操作路由和
+embedding 模型事实混在一起的配置模型。
+
+## 用户结果
+
+- OpenAI-compatible endpoint 可以包含任意合法路径前缀；open-compute 使用 operator 配置的完整 endpoint URL，不再覆盖路径或拼接固定路由。
+- Embeddings 与 chat completions 分别引用 operation-specific backend，同一供应商可以为不同操作使用不同 host、路径、凭据或静态 metadata headers。
+- 每个 embedding 模型只配置 backend、远端模型名和一个可复用 `profile`；维度、输入上限与 tokenizer 不再在 model mapping 中重复填写，cosine metric 不进入配置。
+- profile 由 operator 显式定义并可被多个模型复用，冻结精确维度、tokenizer revision／artifact digest 和输入上限；open-compute 不隐式猜测模型事实。
+- 未配置任何 backend 仍是合法的离线部署；配置加载完整校验 backend/model/profile 引用和 artifact 声明，`ocd` 组合 AI Search 服务时读取并校验 tokenizer bytes。provider 暂时不可达只影响实际调用，启动不探测 provider、不下载模型或 tokenizer。
+
+## 当前问题
+
+当前 `[ai.providers.*].base_url` 必须是 canonical `/v1` root，随后 client 分别拼接 `/embeddings` 和
+`/chat/completions`。这种模型存在四个问题：
+
+1. `https://provider.example/compatible-mode/v1` 之类带前缀的 root 会被当前校验拒绝；endpoint 派生逻辑也会用 `/v1` 覆盖原 path，无法接入 #41 的 provider。
+2. 一个 provider 同时承担供应商身份、认证、协议和多个操作地址，无法表达 embeddings/chat 位于不同地址的常见部署。
+3. embedding model 配置要求重复填写维度、metric、token 上限、tokenizer family/revision/path/SHA；其中 metric 实际只能是 cosine。
+4. embedding alias 仍受硬编码 Cloudflare model 表约束，新增兼容模型必须修改生产代码，operator catalog 并不真正通用。
+
+只放宽 `base_url` 的 path 校验仍然保留操作路由拼接和多操作耦合，因此不是本阶段的最终模型。
+
+## 权责模型
+
+| 层级 | 负责 | 不负责 |
+| --- | --- | --- |
+| Backend | 一种固定 wire protocol、完整 endpoint URL、认证方式、受限静态 headers | 模型维度、tokenizer、索引 metric、tenant alias |
+| Embedding profile | 维度、输入 token 上限、精确 tokenizer、是否发送 dimensions 参数 | endpoint、secret、远端模型名 |
+| Model mapping | tenant-visible alias 到 backend、remote model、profile 的映射 | transport 实现、tokenizer bytes |
+| Resolved contract | 展开并冻结所有影响 chunk/embed/index 的非 secret 事实 | secret value、并发、timeout 等运行策略 |
+
+`backend` 是一次具体操作的调用目标，不是供应商账户的抽象。协议使用闭集；P5.2 首先提供
+`openai_embeddings_v1` 和 `openai_chat_completions_v1`，不引入任意 JSON template、脚本或动态 adapter。
+
+## 配置合同
+
+### Backend
+
+```toml
+[ai.backends.bailian-embeddings]
+protocol = "openai_embeddings_v1"
+endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+auth = { kind = "bearer", secret = { env = "DASHSCOPE_API_KEY" } }
+
+[ai.backends.bailian-chat]
+protocol = "openai_chat_completions_v1"
+endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+auth = { kind = "bearer", secret = { env = "DASHSCOPE_API_KEY" } }
+headers = { "HTTP-Referer" = "https://open-compute.dev", "X-Title" = "open-compute" }
+```
+
+`endpoint` 是最终请求 URL。adapter 不追加、删除或替换 path segment。URL 必须 canonical；禁止 userinfo、query 和 fragment，
+非 loopback 地址必须使用 HTTPS，`auth = { kind = "none" }` 仍只允许 loopback HTTP。redirect 不跟随。
+
+认证使用闭集：
+
+```toml
+# 标准 Authorization: Bearer
+auth = { kind = "bearer", secret = { env = "PROVIDER_API_KEY" } }
+
+# 使用自定义 header 发送一个 API key
+auth = { kind = "header", name = "X-API-Key", secret = { file = "/run/secrets/provider-api-key" } }
+
+# 只允许 loopback HTTP
+auth = { kind = "none" }
+```
+
+`headers` 只承载非敏感静态 metadata。secret 不允许通过 `${ENV}`、模板或普通 header value 注入，必须走现有 env/file
+`SecretReference`。P5.2 不支持任意多个 secret headers；真实 provider 出现这种需求后，再增加语义和泄漏边界明确的 auth kind。
+
+Header 在配置加载时统一校验：
+
+- 名称按 ASCII lowercase 比较并拒绝重复；数量、名称和值都有硬上限，值禁止换行和控制字符；
+- `Authorization` 只由 `auth.kind = "bearer"` 生成，普通 `headers` 和 `auth.kind = "header"` 均不得使用它；自定义 auth header name 也不能与普通 header 冲突；
+- `Host`、`Content-Length`、`Content-Type`、`Accept`、`User-Agent`、`Cookie`、`Connection`、`Transfer-Encoding`、`Upgrade`、`TE`、`Trailer` 和 proxy/hop-by-hop headers 由平台拥有或禁止，operator 不能覆盖；
+- adapter 先生成平台拥有的 request headers，再加入已经验证的认证与静态 headers，不接受 tenant request 提供 backend headers；
+- secret value 永不进入 config serialization、日志、错误、metrics、doctor、support bundle 或持久化 contract。
+
+### Embedding profile 与 model mapping
+
+```toml
+[ai.embedding_profiles."qwen/qwen3-1024"]
+dimensions = 1024
+max_input_tokens = 8192
+send_dimensions = true
+tokenizer = { kind = "qwen3", revision = "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3", artifact = { path = "/opt/open-compute/tokenizers/qwen3/tokenizer.json", sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" } }
+
+[ai.embedding_models."@cf/qwen/qwen3-embedding-0.6b"]
+backend = "bailian-embeddings"
+remote_model = "text-embedding-v4"
+profile = "qwen/qwen3-1024"
+```
+
+`remote_model` 是请求体实际发送的值；`profile` 是 open-compute 对 embedding 行为的本地、不可变描述。二者不要求同名，
+同一 profile 可以被不同 provider 的 model mapping 复用。
+
+profile 不区分 built-in 与 custom，也没有保留名字空间。这样既保留复用能力，又不让单二进制为一组不断变化且有独立 license 的
+模型资源兜底。operator 必须显式提供 digest-pinned 的本地 tokenizer artifact；启动和请求路径都不下载 tokenizer。新增 provider
+通常只需复用现有 profile 并增加 model mapping，只有模型的 embedding 行为确实不同时才新增 profile。
+
+另一个 profile 示例：
+
+```toml
+[ai.embedding_profiles."company/embed-v2"]
+dimensions = 768
+max_input_tokens = 4096
+send_dimensions = false
+tokenizer = { kind = "custom", revision = "2026-08-01", artifact = { path = "/opt/open-compute/tokenizers/embed-v2.json", sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" } }
+
+[ai.embedding_models."company/embed-v2"]
+backend = "internal-embeddings"
+remote_model = "embed-v2"
+profile = "company/embed-v2"
+provider_revision = "2026-08-01"
+```
+
+每个 profile 必须声明维度、平台采用的最大输入 token 数和 digest-pinned offline tokenizer。`send_dimensions` 默认为
+`false`；为 `true` 时 adapter 发送与 `dimensions` 相同的数值，不再保留两个可能冲突的数字字段。
+
+`provider_revision` 只在上游确实提供不可变 revision 时填写，不能要求 operator 编造一个无法验证的版本字符串。它存在时进入
+resolved contract。配置解析不通过请求一个样本文本来推断维度或 revision；首次响应也不能成为持久数据契约。
+
+### Generation model
+
+Generation mapping 改为引用声明了 `openai_chat_completions_v1` 的 backend：
+
+```toml
+[ai.generation_models."company/chat"]
+backend = "bailian-chat"
+remote_model = "qwen-plus"
+max_context_tokens = 32768
+capabilities = ["chat", "rewrite", "rerank"]
+```
+
+Generation 不使用 embedding profile。`max_context_tokens` 与 capabilities 继续属于 model mapping；它们不能进入 backend，
+因为同一 endpoint 可以承载多个能力不同的模型。
+
+## 维度、tokenizer 与 metric
+
+- **Dimensions 必须进入 resolved contract。** provider response、持久向量 bytes 和索引 generation 都依赖精确维度。它在可复用
+  profile 中只填写一次。
+- **Tokenizer 必须进入 resolved contract。** tokenizer 改变 chunk 边界及重建结果。profile 必须提供 revision 和 artifact SHA，
+  持久化时只记录 revision/digest，不记录 host path。
+- **AI Search metric 不进入用户配置。** P5.2 固定 cosine，并在 resolved contract 中显式记录。当前单值 `metric = "cosine"`
+  是配置噪声，应删除。独立 Vectorize index 的 cosine/euclidean/dot-product 仍是公开索引配置，不受本方案影响。
+- **Max input tokens 属于 profile。** 它是 open-compute 采用的安全上限，不必等于供应商宣传的理论 context window；configured
+  chunk size 仍不得超过该值。
+
+## 响应兼容边界
+
+OpenAI-compatible 表示请求和核心响应结构兼容，不表示返回 JSON 必须逐字段等于 OpenAI 当前实现。adapter 应当：
+
+- 忽略未知响应字段，但继续限制总 response bytes、集合大小和字符串大小；
+- 对 embeddings 强制检查 item count、唯一且完整的 index、有限浮点数和 profile dimensions；
+- 不再要求 response `model` 与请求的 `remote_model` 字节完全相等；该字段允许缺失或由 provider canonicalize，但存在时必须是
+  bounded non-empty string；
+- 对 chat/non-stream/SSE 继续检查 choices、index、role/content、终止标记、deadline 和 malformed frame；
+- 保留现有 unauthorized、rate-limit、transient、permanent、timeout 和 malformed-response 稳定错误分类，不返回上游 body。
+
+这些兼容放宽不允许接受维度漂移、NaN/Infinity、重复 index、不完整 SSE、redirect 或超限响应。
+
+## 冻结、更新与失败语义
+
+创建或更新 AI Search instance 时，service 把 backend 与 profile 展开成一个 secret-free resolved contract。至少冻结：
+
+- backend protocol、canonical endpoint digest、auth kind／自定义 auth header name；
+- 按 lowercase 排序的静态 header names 及 values digest；
+- remote model 与可选 provider revision；
+- profile identity/definition digest、dimensions、cosine、max input tokens、`send_dimensions`；
+- tokenizer kind、revision 和 artifact SHA。
+
+endpoint、protocol、auth kind/name、静态 header 或 remote model、provider revision、任一 profile 事实改变时，model contract
+digest 必须改变，并通过现有 generation fence 完整 reindex 后再激活。secret value 轮换、timeout、并发和请求池大小不改变
+embedding 语义，不触发 reindex。静态 header 可能参与上游 deployment/version routing，因此其值只存摘要，但变化仍保守地视为语义变化。
+
+配置加载同步验证所有 backend/model/profile 引用和 tokenizer artifact 声明；服务组合时验证本地 tokenizer bytes。缺失、digest mismatch、未知 profile、protocol/operation
+不匹配或旧 contract shape 一律 fail closed；不保留 `[ai.providers]`、`base_url`、隐式 path append、旧字段 alias 或双读路径。
+已经发布的 SQLite migration bytes 保持不变；若实现需要 schema 变化，只追加下一条 migration。已有旧 contract 数据不被静默修复或
+猜测，operator 必须用新配置显式启动一次受 generation fence 保护的重建。
+
+## 实施范围
+
+- 用 `backends` 替换 `providers`，让 core config、path/secret resolution、header validation、doctor、health、support bundle 和示例共同使用一个模型。
+- 增加 operator embedding profile registry，删除 Cloudflare alias switch、公开单值 metric 及重复
+  `request_dimensions` 数值。
+- 让 embeddings/chat client 直接使用 backend endpoint 和协议；收敛共同的 bounded HTTP/auth/status 逻辑，不增加 pass-through
+  wrapper。
+- 更新 AI Search contract hashing、tokenizer registry、reindex 判定和 restart validation；移除 superseded 类型、字段和测试 fixture。
+- 更新 operator 配置文档、默认配置注释、Cloudflare compatibility/deviation 描述及 #41 的验收证据。
+
+## 非目标
+
+- 任意 request/response transform、用户脚本、动态 module 或自定义 JSON template；
+- 自动模型发现、启动时 capability probe、tokenizer/model 下载；
+- provider fallback、负载均衡、跨 provider retry、成本路由或 multi-region control plane；
+- Azure-specific query authentication、多个 secret headers、tenant-controlled headers 或非 OpenAI-compatible adapter；
+- 改变独立 Vectorize 的公开 metric 支持面。
+
+## 验收结果
+
+- Config tests 已覆盖任意合法 path prefix、embeddings/chat 独立 endpoint、canonical URL、HTTPS/loopback、三种 auth、静态 header bounds/reserved-name/case-insensitive collision，以及所有 backend/model/profile 引用失败。
+- Profile 与持久化 tests 已覆盖复用展开、tokenizer digest、维度/input bounds、`send_dimensions`、稳定 contract hash、旧 shape 拒绝和内嵌 digest 防伪造。
+- Provider process tests 已证明请求命中配置的完整 path；额外 JSON 字段、canonicalized response model 和乱序 item 可接受，维度漂移、非有限向量、重复 item、超限 body、redirect 与 malformed SSE 继续失败。
+- Bearer/custom-header credential 只从引用解析，不进入 resolved contract 或 support bundle；静态 header value 只以摘要进入持久 contract，secret reference 轮换不触发 reindex。
+- 使用本地 operator credential 对阿里云百炼 `qwen3.7-text-embedding-flash` 做了真实 OpenAI-compatible 请求，返回并通过 1024 个有限浮点维度校验；凭据与响应正文未写入输出或仓库。
+- Format、Clippy、no-default-features、Rust 1.98 MSRV、metadata、dependency boundary、文档构建均通过；workspace Rust line coverage 为 90.03%，随后一次完整未插桩 workspace Gate 通过。

--- a/docs/implemented/p5-vectorize-ai-search.md
+++ b/docs/implemented/p5-vectorize-ai-search.md
@@ -10,7 +10,7 @@
 - AI Search namespace／instance 支持 item upload、异步 parse/chunk/embed/index、keyword/vector/hybrid retrieval、rewrite/rerank 和 chat/SSE。
 - 每个 AI Search instance 使用独立 SQLite，原始 document bytes 使用平台 object authority；generation 只有完整提交后才激活。
 - Embedding 与 chat 使用 operator 配置的 OpenAI-compatible HTTPS 或 loopback provider；`ocd` 不内嵌模型、不在启动时联网或下载。
-- `env.AI.toMarkdown()` 和 rich-document indexing 复用 [P5.7 parser](p5-7-xberg-document-parsing.md)，不暴露 Xberg 或私有解析 API。
+- `env.AI.toMarkdown()` 和 rich-document indexing 复用 [P5.1 parser](p5-1-xberg-document-parsing.md)，不暴露 Xberg 或私有解析 API。
 - Delete、cancel、full reindex、provider retry、snapshot/restore 和 GC 使用持久 job／generation fence，旧结果不能覆盖新配置。
 
 实现复用一个 `ocd`、一个 workerd、SQLite 和已选 object backend，不增加 Redis、独立向量数据库、常驻模型 daemon 或第二套 runtime。
@@ -31,4 +31,5 @@
 当日 catalog 为 2,178 members：1,585 `supported`、593 `supported_with_deviation`、`blocked=0`。
 
 本地 exact-only、operator-managed provider 和单机 topology 是接受限制。ANN、OCR、AI Gateway、AutoRAG、continuous ingestion、
-额外 provider adapter 和全球 placement／replication 不在本阶段。
+额外 provider adapter 和全球 placement／replication 不在本阶段；provider/backend 重构由
+[P5.2](p5-2-ai-provider-profiles.md)完成重构。

--- a/docs/references/runbooks/collect-support-bundle.md
+++ b/docs/references/runbooks/collect-support-bundle.md
@@ -19,10 +19,10 @@
 content-free events/receipts、文件摘要与 `search.json`。`observability.sqlite`、WAL/SHM、Workers Logs event/source、
 query/filter value、tail frame、tail session/ticket/URL 和 collector envelope 一律不进入 bundle；只允许 health、容量、
 retention、oldest-event age 与 bounded drop counter。`search.json` 只公开 Vectorize/AI Search resource 的 bounded
-count/health status、schema version 和 AI provider catalog contract digest；不含 vector values、metadata、
-chunk/document text、object key、provider endpoint 或 credential。Markdown Conversion 的原始文档、规范化 Markdown、
+count/health status、schema version 和 AI backend catalog contract digest；不含 vector values、metadata、
+chunk/document text、object key、backend endpoint 或 credential。Markdown Conversion 的原始文档、规范化 Markdown、
 OCDP stdin/stdout、parser 临时目录和 child stderr 正文同样不进入 bundle；只允许 content-free stable
-error/counter。Local object absolute path、object key、payload sample 和 customer key 一律不输出。secret scanner 覆盖 master key、S3/admin credential、所有 Bearer AI provider secret，以及测试注入的
+error/counter。Local object absolute path、object key、payload sample 和 customer key 一律不输出。secret scanner 覆盖 master key、S3/admin credential、所有 bearer/custom-header AI backend secret，以及测试注入的
 observability/tail canary。secret canary、size cap、目标已存在或路径不规范是停止条件；不要绕过 scanner 或手工添加
 DB、DO、bundle、request body、日志、tail、文档、key/credential。回滚是由 operator 对这个精确文件执行受控销毁。
 验证是校验输出 SHA-256、离线查看 entry 名并复核无 secret、Workers Logs、tail、向量或文档内容。

--- a/packages/docs/ocd/configuration.md
+++ b/packages/docs/ocd/configuration.md
@@ -25,6 +25,33 @@ Secrets are references only. Do not put them in units, images, the repository, o
 
 Every admin listener, including loopback, requires all three role tokens. Startup rejects equal resolved token values instead of relying on match order.
 
+## `[ai]`: provider backends and embedding profiles
+
+An AI backend is one operation-specific, final request URL. `ocd` never appends `/embeddings` or `/chat/completions`, so include any provider path prefix and the operation route in `endpoint`:
+
+```toml
+[ai.backends.bailian-embeddings]
+protocol = "openai_embeddings_v1"
+endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+auth = { kind = "bearer", secret = { env = "DASHSCOPE_API_KEY" } }
+headers = { "X-Title" = "open-compute" }
+
+[ai.embedding_profiles."qwen/qwen3-1024"]
+dimensions = 1024
+max_input_tokens = 8192
+send_dimensions = true
+tokenizer = { kind = "qwen3", revision = "pinned-tokenizer-revision", artifact = { path = "/opt/open-compute/tokenizers/qwen3/tokenizer.json", sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" } }
+
+[ai.embedding_models."company/qwen-embedding"]
+backend = "bailian-embeddings"
+remote_model = "text-embedding-v4"
+profile = "qwen/qwen3-1024"
+```
+
+Authentication is a closed choice: `bearer`, one custom secret `header`, or `none`. For providers that require a custom key header, use `auth = { kind = "header", name = "X-API-Key", secret = { file = "/run/secrets/provider-key" } }`. The optional `headers` map is only for non-secret static metadata. It cannot override `Authorization`, the custom auth header, host/content headers, cookies, proxy headers, or hop-by-hop headers. `none` is accepted only for loopback HTTP; non-loopback endpoints require HTTPS.
+
+Profiles keep model facts reusable without making them implicit. Dimensions, maximum input tokens, whether to send `dimensions`, and a digest-pinned offline tokenizer belong in the profile. AI Search fixes its metric to cosine. `config check` validates the artifact declaration without reading it; `ocd` verifies the local bytes while composing AI Search services and never downloads a tokenizer.
+
 ## `[data]`: platform state and lock
 
 `[data]`:
@@ -69,6 +96,6 @@ A failed upload is not committed. An initialized platform is bound to its backen
 
 ## Other sections
 
-The template also includes `[server]`, `[runtime]`, `[cache]`, `[response_cache]`, `[images]`, `[metrics]`, `[hardening]`, `[workers]`, `[kv]`, `[r2]`, `[d1]`, `[queues]`, `[durable_objects]`, `[scheduler]` (including pools), and `[workflows]`. These are local quotas and timeouts, not Cloudflare plan SKUs. Run `config check` before changing them, then `capabilities --json` for actual `limits`.
+The template also includes `[server]`, `[runtime]`, `[cache]`, `[response_cache]`, `[images]`, `[ai]`, `[metrics]`, `[hardening]`, `[workers]`, `[kv]`, `[r2]`, `[d1]`, `[queues]`, `[durable_objects]`, `[scheduler]` (including pools), and `[workflows]`. These are local quotas and timeouts, not Cloudflare plan SKUs. Run `config check` before changing them, then `capabilities --json` for actual `limits`.
 
 `hardening.emergency_reserve_bytes` must be below the `[data]` hard reserve.

--- a/packages/docs/zh/ocd/configuration.md
+++ b/packages/docs/zh/ocd/configuration.md
@@ -25,6 +25,33 @@ ocd --config /etc/open-compute/config.toml config check
 
 所有 admin listener（包括 loopback）都必须配置三类角色 token；解析后 token 值相同会拒绝启动，不按匹配顺序降权。
 
+## `[ai]`：provider backend 与 embedding profile
+
+一个 AI backend 表示一个 operation-specific 最终请求 URL。`ocd` 不会追加 `/embeddings` 或 `/chat/completions`，因此 `endpoint` 必须同时包含 provider 的路径前缀和操作路由：
+
+```toml
+[ai.backends.bailian-embeddings]
+protocol = "openai_embeddings_v1"
+endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+auth = { kind = "bearer", secret = { env = "DASHSCOPE_API_KEY" } }
+headers = { "X-Title" = "open-compute" }
+
+[ai.embedding_profiles."qwen/qwen3-1024"]
+dimensions = 1024
+max_input_tokens = 8192
+send_dimensions = true
+tokenizer = { kind = "qwen3", revision = "pinned-tokenizer-revision", artifact = { path = "/opt/open-compute/tokenizers/qwen3/tokenizer.json", sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" } }
+
+[ai.embedding_models."company/qwen-embedding"]
+backend = "bailian-embeddings"
+remote_model = "text-embedding-v4"
+profile = "qwen/qwen3-1024"
+```
+
+认证是闭集：`bearer`、单个自定义 secret `header` 或 `none`。需要自定义 key header 时写成 `auth = { kind = "header", name = "X-API-Key", secret = { file = "/run/secrets/provider-key" } }`。可选 `headers` map 只承载非敏感静态 metadata，不能覆盖 `Authorization`、自定义 auth header、host/content header、cookie、proxy 或 hop-by-hop header。`none` 只允许 loopback HTTP；非 loopback endpoint 必须使用 HTTPS。
+
+Profile 让模型事实可复用而不变成隐式猜测。维度、最大输入 token 数、是否发送 `dimensions`，以及 digest-pinned offline tokenizer 都属于 profile；AI Search 的 metric 固定为 cosine。`config check` 只验证 artifact 声明而不读取文件；`ocd` 组合 AI Search 服务时校验本地 bytes，绝不下载 tokenizer。
+
 ## `[data]`：平台状态与锁
 
 `[data]`：
@@ -69,6 +96,6 @@ S3 使用 AWS SDK SigV4：
 
 ## 其它段
 
-模板还包含 `[server]`、`[runtime]`、`[cache]`、`[response_cache]`、`[images]`、`[metrics]`、`[hardening]`、`[workers]`、`[kv]`、`[r2]`、`[d1]`、`[queues]`、`[durable_objects]`、`[scheduler]`（含 pool）和 `[workflows]`。这些是本机配额与超时，不是 Cloudflare 套餐。改之前用 `config check`，改完用 `capabilities --json` 看实际 `limits`。
+模板还包含 `[server]`、`[runtime]`、`[cache]`、`[response_cache]`、`[images]`、`[ai]`、`[metrics]`、`[hardening]`、`[workers]`、`[kv]`、`[r2]`、`[d1]`、`[queues]`、`[durable_objects]`、`[scheduler]`（含 pool）和 `[workflows]`。这些是本机配额与超时，不是 Cloudflare 套餐。改之前用 `config check`，改完用 `capabilities --json` 看实际 `limits`。
 
 `hardening.emergency_reserve_bytes` 必须低于 `[data]` 的 hard reserve。

--- a/share/default-config.toml
+++ b/share/default-config.toml
@@ -110,6 +110,26 @@ max_embedding_response_bytes = 16777216
 provider_timeout_ms = 30000
 query_timeout_ms = 15000
 
+# Backends use final operation URLs; ocd does not append a route. Credentials
+# are secret references. Optional headers are non-secret static metadata only.
+#
+# [ai.backends.example-embeddings]
+# protocol = "openai_embeddings_v1"
+# endpoint = "https://provider.example/compatible-mode/v1/embeddings"
+# auth = { kind = "bearer", secret = { env = "PROVIDER_API_KEY" } }
+# headers = { "X-Title" = "open-compute" }
+#
+# [ai.embedding_profiles."example/embed-1024"]
+# dimensions = 1024
+# max_input_tokens = 8192
+# send_dimensions = true
+# tokenizer = { kind = "custom", revision = "pinned-revision", artifact = { path = "/opt/open-compute/tokenizers/example/tokenizer.json", sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" } }
+#
+# [ai.embedding_models."company/embed"]
+# backend = "example-embeddings"
+# remote_model = "provider-model-name"
+# profile = "example/embed-1024"
+
 [metrics]
 enabled = true
 max_label_value_bytes = 64

--- a/test/conformance/baseline.json
+++ b/test/conformance/baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openComputeRevision": "8dd00266b43ce39ce95392cd44b9c749f277ebff132b167c12786dd699dbf8b5",
+  "openComputeRevision": "3b050fa36cacc2309d748ae2d3e70156bdaabd7d6d23eb5da483afc61e005cb1",
   "sourceDigestScope": "git-visible production, test, toolchain, manifest, and maintained reference inputs; excludes generated Python caches, test/conformance/baseline.json, and non-reference docs",
   "workerdLockSha256": "de6a6f64a26f9e5640a8f2ceb2a6de5ab93968e1948ee8c36b35140b121e2de7",
   "workerd": {


### PR DESCRIPTION
## Summary

- replace provider base URLs with operation-specific backends and exact endpoints
- add reusable embedding profiles for dimensions, token limits, tokenizer pins, and optional dimensions requests
- support bearer, custom secret header, and loopback unauthenticated backends with bounded static metadata headers
- freeze the expanded secret-free backend/profile contract and fail closed on obsolete persisted shapes
- document P5.2 and rename the document parsing plan from P5.7 to P5.1

## Validation

- bun run build
- bun run docs:build
- cargo fmt --all --check
- ./test/check-rust-clippy.sh
- RUSTFLAGS=-D warnings cargo check --workspace --no-default-features
- cargo +1.98.0 check --workspace --all-targets
- cargo metadata --no-deps --format-version 1
- ./test/check-boundaries.sh
- ./test/coverage.sh equivalent completed from preserved coverage artifacts: 90.03% workspace line coverage
- OPEN_COMPUTE_TEST_WORKERD=/absolute/verified/workerd ./test/gate.py --workspace: 51 targets passed
- live Alibaba Cloud Bailian OpenAI-compatible embedding probe: 1024 finite dimensions

Closes #41