### PR TITLE
Fix Wrangler tail readiness race for v0.1.7

### DIFF
--- a/crates/service/tests/p6_wrangler_resource_gate/p12.rs
+++ b/crates/service/tests/p6_wrangler_resource_gate/p12.rs
@@ -404,9 +404,9 @@ async fn exercise_wrapper_tail(
         );
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    assert_project(client, fixture, "p12-wrapper-alpha-dev", "alpha", "dev").await;
-    let event_deadline = Instant::now() + Duration::from_secs(5);
+    let event_deadline = Instant::now() + Duration::from_secs(15);
     loop {
+        assert_project(client, fixture, "p12-wrapper-alpha-dev", "alpha", "dev").await;
         let bytes = fs::read(&stdout).unwrap_or_default();
         if String::from_utf8_lossy(&bytes).contains("p12-tail-alpha") {
             break;


### PR DESCRIPTION
Closes a macOS CI race observed during the v0.1.7 release Gate. The test now repeatedly triggers the tail event within the established bounded readiness window, matching the existing tail Gate strategy.\n\nValidation:\n- focused p6-wrangler-resources Gate passed\n- main CI passed: https://github.com/elliothux/open-compute/actions/runs/34722494521